### PR TITLE
Update to match upstream API change (lxd.Client)

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -96,7 +96,7 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 
 	//client.Init = (name string, imgremote string, image string, profiles *[]string, config map[string]string, ephem bool)
 	var resp *lxd.Response
-	if resp, err = client.Init(name, remote, d.Get("image").(string), &profiles, nil, ephem); err != nil {
+	if resp, err = client.Init(name, remote, d.Get("image").(string), &profiles, nil, nil, ephem); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In lxc/lxd@e3a1cb6b0ac5e1cd5daffa801d377fccc673e94b they updated func (c *Client) Init to have another parameter for passing in a list of "devices".  I think we can safely just put a nil here.