### PR TITLE
Randomize Container Names in Testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 test:
 	go get ./...
+	go get github.com/dustinkirkland/golang-petname
 	go test -v ./lxd
 
 testacc:


### PR DESCRIPTION
This commit randomizes the container names when running the acceptance tests
This is to help prevent timing issues and possible naming collisions.