### PR TITLE
Enable acceptance tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: go
-sudo: false
+sudo: true
+dist: trusty
+
+env:
+- TF_ACC=1
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
+  - sudo apt-get -qq update
+  - sudo apt-get install -y lxd
+  - sudo lxd init --auto
+  - sudo chmod 777 /var/lib/lxd/unix.socket
+  - "lxc image copy ubuntu:t local: --alias=ubuntu"
+  - lxc image list
 
 go:
-  - 1.7.3
+  - 1.7.4
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This commit changes the travis config to enable execution of the Acceptance test.

This requires a full Ubuntu trusty environment (not in a container), with LXD installed and an Ubuntu pre-downloaded and aliased as `ubuntu`.