### PR TITLE
lxd_profile resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ resource "lxd_container" "test1" {
     }
   }
 }
+
+resource "lxd_profile" "profile1" {
+  name = "profile1"
+
+  config {
+    limits.cpu = 2
+  }
+}
 ```
 
 ### Reference
@@ -67,6 +75,8 @@ resource "lxd_container" "test1" {
   * `remote`   - *Optional* - Name of the remote LXD as it exists in the local lxc config. Defaults to `local`.
 
 #### Resource
+
+**lxd_container**
 
 ##### Parameters
 
@@ -84,6 +94,19 @@ resource "lxd_container" "test1" {
   * `type`      - *Required* -Type of the device Must be one of none, disk, nic, unix-char, unix-block, usb, gpu.
   * `properties`- *Required* -Map of key/value pairs of [https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration](device properties).
 
+**lxd_profile**
+
+  * `name`      - *Required* -Name of the container.
+  * `config`    - *Optional* -Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
+  * `device`    - *Optional* -Device definition. See reference below.
+
+##### Device Block
+
+  * `name`      - *Required* -Name of the device.
+  * `type`      - *Required* -Type of the device Must be one of none, disk, nic, unix-char, unix-block, usb, gpu.
+  * `properties`- *Required* -Map of key/value pairs of [https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration](device properties).
+
+
 ## Known Limitations
 
 All the base LXD images do not include an SSH server, therefore terraform will be unable to execute any `provisioners`.
@@ -96,5 +119,4 @@ A basic base image must be prepared in advance, that includes the SSH server.
 - [ ] Ability to exec commands via LXD WebSocket channel
 - [ ] Ability to upload files via LXD WebSocket channel
 - [ ] Volumes support
-- [ ] Add LXD `profile` resource
 - [ ] Add LXD `image` resource

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"lxd_container": resourceLxdContainer(),
+			"lxd_profile":   resourceLxdProfile(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -242,6 +242,28 @@ func testAccContainerConfig(container *shared.ContainerInfo, k, v string) resour
 	}
 }
 
+func testAccContainerExpandedConfig(container *shared.ContainerInfo, k, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if container.ExpandedConfig == nil {
+			return fmt.Errorf("No expanded config")
+		}
+
+		for key, value := range container.ExpandedConfig {
+			if k != key {
+				continue
+			}
+
+			if v == value {
+				return nil
+			}
+
+			return fmt.Errorf("Bad value for %s: %s", k, value)
+		}
+
+		return fmt.Errorf("Expanded Config not found: %s", k)
+	}
+}
+
 func testAccContainerProfile(container *shared.ContainerInfo, profile string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if container.Profiles == nil {
@@ -269,6 +291,20 @@ func testAccContainerDevice(container *shared.ContainerInfo, deviceName string, 
 		}
 
 		return fmt.Errorf("Device not found: %s", deviceName)
+	}
+}
+
+func testAccContainerExpandedDevice(container *shared.ContainerInfo, deviceName string, device shared.Device) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if container.ExpandedDevices == nil {
+			return fmt.Errorf("No expanded devices")
+		}
+
+		if container.ExpandedDevices.Contains(deviceName, device) {
+			return nil
+		}
+
+		return fmt.Errorf("Expanded Device not found: %s", deviceName)
 	}
 }
 

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -1,0 +1,179 @@
+package lxd
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func resourceLxdProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLxdProfileCreate,
+		Update: resourceLxdProfileUpdate,
+		Delete: resourceLxdProfileDelete,
+		Exists: resourceLxdProfileExists,
+		Read:   resourceLxdProfileRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"device": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"type": &schema.Schema{
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: resourceLxdValidateDeviceType,
+						},
+
+						"properties": &schema.Schema{
+							Type:     schema.TypeMap,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceLxdProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+	config := resourceLxdConfigMap(d.Get("config"))
+	devices := resourceLxdDevices(d.Get("device"))
+
+	if err := client.ProfileCreate(name); err != nil {
+		return err
+	}
+
+	profile := shared.ProfileConfig{
+		Name:        name,
+		Config:      config,
+		Description: description,
+		Devices:     devices,
+	}
+
+	if err := client.PutProfile(name, profile); err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return resourceLxdProfileRead(d, meta)
+}
+
+func resourceLxdProfileRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	profile, err := client.ProfileConfig(name)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Retrieved profile %s: %#v", name, profile)
+
+	d.Set("description", profile.Description)
+	d.Set("config", profile.Config)
+	d.Set("device", profile.Devices)
+
+	return nil
+}
+
+func resourceLxdProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	var changed bool
+
+	profile, err := client.ProfileConfig(name)
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("description") {
+		changed = true
+		_, newDescription := d.GetChange("description")
+		profile.Description = newDescription.(string)
+	}
+
+	if d.HasChange("device") {
+		changed = true
+		old, new := d.GetChange("device")
+		oldDevices := resourceLxdDevices(old)
+		newDevices := resourceLxdDevices(new)
+
+		for n, _ := range oldDevices {
+			delete(profile.Devices, n)
+		}
+
+		for n, d := range newDevices {
+			if n != "" {
+				profile.Devices[n] = d
+			}
+		}
+
+		log.Printf("[DEBUG] Updated device list: %#v", profile.Devices)
+	}
+
+	if changed {
+		err := client.PutProfile(name, *profile)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceLxdProfileDelete(d *schema.ResourceData, meta interface{}) (err error) {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	if err = client.ProfileDelete(name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceLxdProfileExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	exists = false
+
+	profile, err := client.ProfileConfig(name)
+	if err == nil && profile != nil {
+		exists = true
+	}
+
+	return
+}

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -1,0 +1,457 @@
+package lxd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func TestAccProfile_basic(t *testing.T) {
+	var profile shared.ProfileConfig
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_basic(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_config(t *testing.T) {
+	var profile shared.ProfileConfig
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_config(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "config.limits.cpu", "2"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileConfig(&profile, "limits.cpu", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_device(t *testing.T) {
+	var profile shared.ProfileConfig
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+
+	device1 := shared.Device{
+		"type":   "disk",
+		"source": "/tmp",
+		"path":   "/tmp/shared",
+	}
+
+	device2 := shared.Device{
+		"type":   "disk",
+		"source": "/tmp",
+		"path":   "/tmp/shared2",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_device_1(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileDevice(&profile, "shared", device1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccProfile_device_2(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared2"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileDevice(&profile, "shared", device2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_addDevice(t *testing.T) {
+	var profile shared.ProfileConfig
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+
+	device := shared.Device{
+		"type":   "disk",
+		"source": "/tmp",
+		"path":   "/tmp/shared",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_addDevice_1(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+				),
+			},
+			resource.TestStep{
+				Config: testAccProfile_addDevice_2(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileDevice(&profile, "shared", device),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_removeDevice(t *testing.T) {
+	var profile shared.ProfileConfig
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+
+	device := shared.Device{
+		"type":   "disk",
+		"source": "/tmp",
+		"path":   "/tmp/shared",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_removeDevice_1(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileDevice(&profile, "shared", device),
+				),
+			},
+			resource.TestStep{
+				Config: testAccProfile_removeDevice_2(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileNoDevice(&profile, "shared", device),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_containerBasic(t *testing.T) {
+	var profile shared.ProfileConfig
+	var container shared.ContainerInfo
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_containerBasic(profileName, containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					testAccContainerProfile(&container, profileName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_containerConfig(t *testing.T) {
+	var profile shared.ProfileConfig
+	var container shared.ContainerInfo
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_containerConfig(profileName, containerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "config.limits.cpu", "2"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					testAccProfileConfig(&profile, "limits.cpu", "2"),
+					testAccContainerExpandedConfig(&container, "limits.cpu", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccProfile_containerDevice(t *testing.T) {
+	var profile shared.ProfileConfig
+	var container shared.ContainerInfo
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	device := shared.Device{
+		"type":   "disk",
+		"source": "/tmp",
+		"path":   "/tmp/shared",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_containerDevice(profileName, containerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					testAccProfileDevice(&profile, "shared", device),
+					testAccContainerExpandedDevice(&container, "shared", device),
+				),
+			},
+		},
+	})
+}
+
+func testAccProfileRunning(t *testing.T, n string, profile *shared.ProfileConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client := testAccProvider.Meta().(*LxdProvider).Client
+		p, err := client.ProfileConfig(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if p != nil {
+			*profile = *p
+			return nil
+		}
+
+		return fmt.Errorf("Profile not found: %s", rs.Primary.ID)
+	}
+}
+
+func testAccProfileConfig(profile *shared.ProfileConfig, k, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if profile.Config == nil {
+			return fmt.Errorf("No config")
+		}
+
+		for key, value := range profile.Config {
+			if k != key {
+				continue
+			}
+
+			if v == value {
+				return nil
+			}
+
+			return fmt.Errorf("Bad value for %s: %s", k, value)
+		}
+
+		return fmt.Errorf("Config not found: %s", k)
+	}
+}
+
+func testAccProfileDevice(profile *shared.ProfileConfig, deviceName string, device shared.Device) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if profile.Devices == nil {
+			return fmt.Errorf("No devices")
+		}
+
+		if profile.Devices.Contains(deviceName, device) {
+			return nil
+		}
+
+		return fmt.Errorf("Device not found: %s", deviceName)
+	}
+}
+
+func testAccProfileNoDevice(profile *shared.ProfileConfig, deviceName string, device shared.Device) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if profile.Devices == nil {
+			return nil
+		}
+
+		if profile.Devices.Contains(deviceName, device) {
+			return fmt.Errorf("Device still exists: %s", deviceName)
+		}
+
+		return nil
+	}
+}
+
+func testAccProfile_basic(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+  name = "%s"
+}`, name)
+}
+
+func testAccProfile_config(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+  name = "%s"
+  config {
+    limits.cpu = 2
+  }
+}`, name)
+}
+
+func testAccProfile_device_1(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+
+	device {
+		name = "shared"
+		type = "disk"
+		properties {
+			source = "/tmp"
+			path = "/tmp/shared"
+		}
+	}
+}`, name)
+}
+
+func testAccProfile_device_2(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+
+	device {
+		name = "shared"
+		type = "disk"
+		properties {
+			source = "/tmp"
+			path = "/tmp/shared2"
+		}
+	}
+}`, name)
+}
+
+func testAccProfile_addDevice_1(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+}`, name)
+}
+
+func testAccProfile_addDevice_2(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+
+	device {
+		name = "shared"
+		type = "disk"
+		properties {
+			source = "/tmp"
+			path = "/tmp/shared"
+		}
+	}
+}`, name)
+}
+
+func testAccProfile_removeDevice_1(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+
+	device {
+		name = "shared"
+		type = "disk"
+		properties {
+			source = "/tmp"
+			path = "/tmp/shared"
+		}
+	}
+}`, name)
+}
+
+func testAccProfile_removeDevice_2(name string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+}`, name)
+}
+
+func testAccProfile_containerBasic(profileName, containerName string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+	name = "%s"
+}
+
+resource "lxd_container" "container1" {
+	name = "%s"
+	image = "ubuntu"
+	profiles = ["default", "${lxd_profile.profile1.name}"]
+}`, profileName, containerName)
+}
+
+func testAccProfile_containerConfig(profileName, containerName string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+  name = "%s"
+  config {
+    limits.cpu = 2
+  }
+}
+
+resource "lxd_container" "container1" {
+	name = "%s"
+	image = "ubuntu"
+	profiles = ["default", "${lxd_profile.profile1.name}"]
+}`, profileName, containerName)
+
+}
+func testAccProfile_containerDevice(profileName, containerName string) string {
+	return fmt.Sprintf(`resource "lxd_profile" "profile1" {
+  name = "%s"
+	device {
+		name = "shared"
+		type = "disk"
+		properties {
+			source = "/tmp"
+			path = "/tmp/shared"
+		}
+	}
+}
+
+resource "lxd_container" "container1" {
+	name = "%s"
+	image = "ubuntu"
+	profiles = ["default", "${lxd_profile.profile1.name}"]
+}`, profileName, containerName)
+}

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -1,0 +1,60 @@
+package lxd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func resourceLxdConfigMap(c interface{}) map[string]string {
+	config := make(map[string]string)
+	if v, ok := c.(map[string]interface{}); ok {
+		for key, val := range v {
+			config[key] = val.(string)
+		}
+	}
+
+	log.Printf("[DEBUG] LXD Configuration Map: %#v", config)
+
+	return config
+}
+
+func resourceLxdDevices(d interface{}) shared.Devices {
+	devices := make(shared.Devices)
+	for _, v := range d.([]interface{}) {
+		device := make(shared.Device)
+		d := v.(map[string]interface{})
+		deviceName := d["name"].(string)
+		deviceType := d["type"].(string)
+		deviceProperties := d["properties"].(map[string]interface{})
+		device["type"] = deviceType
+		for key, val := range deviceProperties {
+			device[key] = val.(string)
+		}
+
+		devices[deviceName] = device
+	}
+
+	log.Printf("[DEBUG] LXD Devices: %#v", devices)
+
+	return devices
+}
+
+func resourceLxdValidateDeviceType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validTypes := []string{"none", "disk", "nic", "unix-char", "unix-block", "usb", "gpu"}
+	valid := false
+
+	for _, v := range validTypes {
+		if value == v {
+			valid = true
+		}
+	}
+
+	if !valid {
+		errors = append(errors, fmt.Errorf("Device must have a type of: %v", validTypes))
+	}
+
+	return
+}


### PR DESCRIPTION
This commit adds an `lxd_profile` resource:

```hcl
resource "lxd_profile" "profile1" {
  name = "profile1"
  config {
    limits.cpu = 2
  }
}

resource "lxd_container" "container1" {
  name = "container1"
  image = "ubuntu"
  profiles = ["default", "${lxd_profile.profile1.name}"]
}
```