### PR TITLE
lxd_network resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ It makes use of the [LXD client library](http://github.com/lxc/lxd), which curre
 
 To generate these files and store them in the LXD daemon, follow these [steps](https://linuxcontainers.org/lxd/getting-started-cli/#multiple-hosts).
 
-### Example Configuration
+### Example Configurations
 
-**Provider (HTTPS)**
+#### Provider (HTTPS)
 
 ```hcl
 provider "lxd" {
@@ -28,20 +28,57 @@ provider "lxd" {
 }
 ```
 
-**Resource**
+#### Basic Example
+
+This assumes the LXD server has been configured per the LXD documentation, including running `lxd init` to create a default network configuration.
+
+This example also assumes an image called `ubuntu` has been cached locally on the LXD server. This can be done by running:
+
+```shell
+$ lxc image copy images:ubuntu/xenial/amd64 local: --alias=ubuntu
+```
+
+With those pieces in place, you can launch a basic container with:
 
 ```hcl
-resource "lxd_network" "eth1" {
-  name = "eth1"
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "ubuntu"
+  ephemeral = false
+}
+```
+
+A container can also take a number of configuration and device options. A full reference can be found [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md). For example, to create a container with 2 CPUs and to share the `/tmp` directory with the LXD host:
+
+```hcl
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "ubuntu"
+  ephemeral = false
 
   config {
-    ipv4.address = "10.150.19.1/24"
-    ipv4.nat = "true"
-    ipv6.address = "fd42:474b:622d:259d::1/64"
-    ipv6.nat = "true"
+    limits.cpu = 2
+  }
+
+  device {
+    name = "shared"
+    type = "disk"
+
+    properties {
+      source = "/tmp"
+      path   = "/tmp"
+    }
   }
 }
+```
 
+#### Profiles
+
+Profiles can be used to share common configurations between containers. Profiles accept the same configuration and device options that containers can use.
+
+The order which profiles are specified is important. LXD applies profiles from "left to right", so profile options may be overridden by other profiles.
+
+```hcl
 resource "lxd_profile" "profile1" {
   name = "profile1"
 
@@ -50,37 +87,140 @@ resource "lxd_profile" "profile1" {
   }
 
   device {
-    name = "eth1"
-    type = "nic"
+    name = "shared"
+    type = "disk"
+
     properties {
-      nictype = "bridged"
-      parent = "${lxd_network.eth1.name}"
+      source = "/tmp"
+      path   = "/tmp"
     }
   }
 }
 
 resource "lxd_container" "test1" {
   name      = "test1"
-
-  # this assumes an image has been cached locally with the alias 'ubuntu'
-  # e.g.
-  # lxc image copy images:ubuntu/xenial/amd64 local: --alias=ubuntu
   image     = "ubuntu"
-
-  profiles  = ["default", "${lxd_profile.profile1.name}"]
   ephemeral = false
+  profiles  = ["default", "${lxd_profile.profile1.name}"]
+}
+```
+
+#### Networks
+
+If you're using LXD 2.3 or later, you can create networks with the `lxd_network` resource. See [this](https://www.stgraber.org/2016/10/27/network-management-with-lxd-2-3/) blog post for details about LXD networking and the [configuration reference](https://github.com/lxc/lxd/blob/master/doc/configuration.md) for all network details.
+
+This example creates a standard NAT network similar to what `lxd init` creates. Containers will access this network via their `eth0` interface:
+
+```hcl
+resource "lxd_network" "new_default" {
+  name = "new_default"
+
+  config {
+    ipv4.address = "10.150.19.1/24"
+    ipv4.nat     = "true"
+    ipv6.address = "fd42:474b:622d:259d::1/64"
+    ipv6.nat     = "true"
+  }
+}
+
+resource "lxd_profile" "profile1" {
+  name = "profile1"
 
   device {
-    name = "shared"
-    type = "disk"
+    name = "eth0"
+    type = "nic"
+
     properties {
-      source = "/tmp"
-      path = "/tmp"
+      nictype = "bridged"
+      parent  = "${lxd_network.new_default.name}"
     }
   }
 }
 
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "ubuntu"
+  ephemeral = false
+  profiles  = ["${lxd_profile.profile1.name}"]
+}
 ```
+
+This example creates a second internal network that containers will access via `eth1`. Containers will use the `default` profile to gain access to the default network on `eth0`.
+
+```hcl
+resource "lxd_network" "internal" {
+  name = "internal"
+
+  config {
+    ipv4.address = "192.168.255.1/24"
+  }
+}
+
+resource "lxd_profile" "profile1" {
+  name = "profile1"
+
+  device {
+    name = "eth1"
+    type = "nic"
+
+    properties {
+      nictype = "bridged"
+      parent  = "${lxd_network.internal.name}"
+    }
+  }
+}
+
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "ubuntu"
+  ephemeral = false
+  profiles  = ["default", "${lxd_profile.profile1.name}"]
+
+	provisioner "local-exec" {
+		command = "lxc exec local:${self.name} dhclient eth1"
+	}
+}
+```
+
+Finally, LXD networks can be used to create tunnels to other LXD servers. In order to create a tunnel, designate one LXD server as the tunnel "server". This server will offer DHCP leases to the tunnel "client". For example:
+
+```hcl
+resource "lxd_network" "vxtun" {
+  name = "vxtun"
+
+  config {
+    tunnel.vxtun.protocol = "vxlan"
+    tunnel.vxtun.id       = 9999
+    tunnel.vxtun.local    = "10.1.1.1"
+    tunnel.vxtun.remote   = "10.255.1.1"
+    ipv4.address          = "192.168.255.1/24"
+    ipv6.address          = "none"
+  }
+}
+```
+
+For the tunnel client:
+
+```hcl
+resource "lxd_network" "vxtun" {
+  name = "vxtun"
+
+  config {
+    tunnel.vxtun.protocol = "vxlan"
+    tunnel.vxtun.id       = 9999
+    tunnel.vxtun.local    = "10.255.1.1"
+    tunnel.vxtun.remote   = "10.1.1.1"
+    ipv4.address          = "none"
+    ipv6.address          = "none"
+  }
+}
+```
+
+Note how the `local` and `remote` addresses are swapped between the two. Also note how the client does not provide an IP address range.
+
+With these resources in place, attach them to a profile in the exact same way described in the other examples.
+
+_note_: `local` and `remote` accept both IPv4 and IPv6 addresses.
 
 ## Reference
 
@@ -99,15 +239,19 @@ resource "lxd_container" "test1" {
 
 The following resources currently exist:
 
-  * `lxd_profile` - Creates and manages a Profile
-  * `lxd_network` - Creates and manages a Network
   * `lxd_container` - Creates and manages a Container
+  * `lxd_network` - Creates and manages a Network
+  * `lxd_profile` - Creates and manages a Profile
 
-#### lxd_profile
+#### lxd_container
 
 ##### Parameters
 
   * `name`      - *Required* -Name of the container.
+  * `image`     - *Required* -Base image from which the container will be created.
+  * `profiles`  - *Optional* -Array of LXD config profiles to apply to the new container.
+  * `ephemeral` - *Optional* -Boolean indicating if this container is ephemeral. Default = false.
+  * `privileged`- *Optional* -Boolean indicating if this container will run in privileged mode. Default = false.
   * `config`    - *Optional* -Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
   * `device`    - *Optional* -Device definition. See reference below.
 
@@ -129,15 +273,11 @@ The following resources currently exist:
   * `type`      - The type of network. This will be either bridged or physical.
   * `managed`   - Whether or not the network is managed.
 
-#### lxd_container
+#### lxd_profile
 
 ##### Parameters
 
   * `name`      - *Required* -Name of the container.
-  * `image`     - *Required* -Base image from which the container will be created.
-  * `profiles`  - *Optional* -Array of LXD config profiles to apply to the new container.
-  * `ephemeral` - *Optional* -Boolean indicating if this container is ephemeral. Default = false.
-  * `privileged`- *Optional* -Boolean indicating if this container will run in privileged mode. Default = false.
   * `config`    - *Optional* -Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
   * `device`    - *Optional* -Device definition. See reference below.
 

--- a/lxd/errors.go
+++ b/lxd/errors.go
@@ -1,0 +1,9 @@
+package lxd
+
+import (
+	"errors"
+)
+
+var ErrNetworksNotImplemented = errors.New("This LXD server does not support " +
+	"the creation of networks. You must be running LXD 2.3 or later for this " +
+	"feature.")

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"lxd_container": resourceLxdContainer(),
+			"lxd_network":   resourceLxdNetwork(),
 			"lxd_profile":   resourceLxdProfile(),
 		},
 

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -48,6 +48,10 @@ func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Creating network %s with config: %#v", name, config)
 	if err := client.NetworkCreate(name, config); err != nil {
+		if err.Error() == "not implemented" {
+			err = ErrNetworksNotImplemented
+		}
+
 		return err
 	}
 

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -1,0 +1,104 @@
+package lxd
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceLxdNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLxdNetworkCreate,
+		//Update: resourceLxdNetworkUpdate,
+		Delete: resourceLxdNetworkDelete,
+		Exists: resourceLxdNetworkExists,
+		Read:   resourceLxdNetworkRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"managed": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+
+	name := d.Get("name").(string)
+	config := resourceLxdConfigMap(d.Get("config"))
+
+	log.Printf("[DEBUG] Creating network %s with config: %#v", name, config)
+	if err := client.NetworkCreate(name, config); err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return resourceLxdNetworkRead(d, meta)
+}
+
+func resourceLxdNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	network, err := client.NetworkGet(name)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Retrieved network %s: %#v", name, network)
+
+	d.Set("config", network.Config)
+	d.Set("type", network.Type)
+	d.Set("managed", network.Managed)
+
+	return nil
+}
+
+func resourceLxdNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+	// Network is not able to be updated yet.
+	return nil
+}
+
+func resourceLxdNetworkDelete(d *schema.ResourceData, meta interface{}) (err error) {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	if err = client.NetworkDelete(name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceLxdNetworkExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
+	client := meta.(*LxdProvider).Client
+	name := d.Id()
+
+	exists = false
+
+	if _, err := client.NetworkGet(name); err == nil {
+		exists = true
+	}
+
+	return
+}

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -1,0 +1,155 @@
+package lxd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func TestAccNetwork_basic(t *testing.T) {
+	var network shared.NetworkConfig
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetwork_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetworkExists(t, "lxd_network.eth1", &network),
+					testAccNetworkConfig(&network, "ipv4.address", "10.150.19.1/24"),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "name", "eth1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetwork_attach(t *testing.T) {
+	var network shared.NetworkConfig
+	var profile shared.ProfileConfig
+	var container shared.ContainerInfo
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	device := shared.Device{
+		"type":    "nic",
+		"nictype": "bridged",
+		"parent":  "eth1",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetwork_attach(profileName, containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetworkExists(t, "lxd_network.eth1", &network),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "name", "eth1"),
+					testAccProfileDevice(&profile, "eth1", device),
+					testAccContainerExpandedDevice(&container, "eth1", device),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkExists(t *testing.T, n string, network *shared.NetworkConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client := testAccProvider.Meta().(*LxdProvider).Client
+		n, err := client.NetworkGet(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*network = n
+
+		return nil
+	}
+}
+
+func testAccNetworkConfig(network *shared.NetworkConfig, k, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if network.Config == nil {
+			return fmt.Errorf("No config")
+		}
+
+		for key, value := range network.Config {
+			if k != key {
+				continue
+			}
+
+			if v == value {
+				return nil
+			}
+
+			return fmt.Errorf("Bad value for %s: %s", k, value)
+		}
+
+		return fmt.Errorf("Config not found: %s", k)
+	}
+}
+
+func testAccNetwork_basic() string {
+	return fmt.Sprintf(`resource "lxd_network" "eth1" {
+  name = "eth1"
+
+	config {
+		ipv4.address = "10.150.19.1/24"
+		ipv4.nat = "true"
+		ipv6.address = "fd42:474b:622d:259d::1/64"
+		ipv6.nat = "true"
+	}
+}`)
+}
+
+func testAccNetwork_attach(profileName, containerName string) string {
+	return fmt.Sprintf(`resource "lxd_network" "eth1" {
+  name = "eth1"
+
+	config {
+		ipv4.address = "10.150.19.1/24"
+		ipv4.nat = "true"
+		ipv6.address = "fd42:474b:622d:259d::1/64"
+		ipv6.nat = "true"
+	}
+}
+
+resource "lxd_profile" "profile1" {
+	name = "%s"
+
+	device {
+		name = "eth1"
+		type = "nic"
+		properties {
+			nictype = "bridged"
+			parent = "${lxd_network.eth1.name}"
+		}
+	}
+}
+
+resource "lxd_container" "container1" {
+	name = "%s"
+	image = "ubuntu"
+	profiles = ["default", "${lxd_profile.profile1.name}"]
+}`, profileName, containerName)
+}


### PR DESCRIPTION
This commit adds an `lxd_network` resource which can be used to create LXD managed networks and tunnels.

```hcl
resource "lxd_network" "eth1" {
  name = "eth1"

  config {
    ipv4.address = "10.150.19.1/24"
    ipv4.nat = "true"
    ipv6.address = "fd42:474b:622d:259d::1/64"
    ipv6.nat = "true"
  }
}
```