### PR TITLE
Fix failure when container no longer exists

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -309,6 +309,9 @@ func resourceLxdContainerExists(d *schema.ResourceData, meta interface{}) (exist
 	exists = false
 
 	ct, err := client.ContainerState(name)
+	if err != nil && err.Error() == "not found" {
+		err = nil
+	}
 	if err == nil && ct != nil {
 		exists = true
 	}


### PR DESCRIPTION
If you create a container with terraform and then delete it by hand,
terraform plan fails because client.ContainerState returns an error.

This bug is subtle because go allows partial variable shadowing when
using := to assign to multiple variables. (err is already declared as a
named return parameter.)