### PR TITLE
Container File Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,26 +247,36 @@ The following resources currently exist:
 
 ##### Parameters
 
-  * `name`      - *Required* -Name of the container.
-  * `image`     - *Required* -Base image from which the container will be created.
-  * `profiles`  - *Optional* -Array of LXD config profiles to apply to the new container.
-  * `ephemeral` - *Optional* -Boolean indicating if this container is ephemeral. Default = false.
-  * `privileged`- *Optional* -Boolean indicating if this container will run in privileged mode. Default = false.
-  * `config`    - *Optional* -Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
-  * `device`    - *Optional* -Device definition. See reference below.
+  * `name`      - *Required* - Name of the container.
+  * `image`     - *Required* - Base image from which the container will be created.
+  * `profiles`  - *Optional* - Array of LXD config profiles to apply to the new container.
+  * `ephemeral` - *Optional* - Boolean indicating if this container is ephemeral. Default = false.
+  * `privileged`- *Optional* - Boolean indicating if this container will run in privileged mode. Default = false.
+  * `config`    - *Optional* - Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
+  * `device`    - *Optional* - Device definition. See reference below.
+  * `file`      - *Optional* - File to upload to the container. See reference below.
 
 ##### Device Block
 
-  * `name`      - *Required* -Name of the device.
-  * `type`      - *Required* -Type of the device Must be one of none, disk, nic, unix-char, unix-block, usb, gpu.
-  * `properties`- *Required* -Map of key/value pairs of [device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration).
+  * `name`      - *Required* - Name of the device.
+  * `type`      - *Required* - Type of the device Must be one of none, disk, nic, unix-char, unix-block, usb, gpu.
+  * `properties`- *Required* - Map of key/value pairs of [device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration).
+
+##### File Block
+
+  * `content` - *Required* - The _contents_ of the file. Use the `file()` function to read in the content of a file from disk.
+  * `target_file` - *Required* - The absolute path of the file on the container, including the filename.
+  * `uid` - *Optional* - The UID of the file. Must be an unquoted integer.
+  * `gid` - *Optional* - The GID of the file. Must be an unquoted integer.
+  * `mode` - *Optional* - The octal permissions of the file, must be quoted.
+  * `create_directories` - *Optional* - Whether to create the directories leading to the target if they do not exist.
 
 #### lxd_network
 
 ##### Parameters
 
-  * `name`      - *Required* -Name of the network. This is usually the device the network will appear as to containers.
-  * `config`    - *Optional* -Map of key/value pairs of [network config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#network-configuration).
+  * `name`      - *Required* - Name of the network. This is usually the device the network will appear as to containers.
+  * `config`    - *Optional* - Map of key/value pairs of [network config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#network-configuration).
 
 ##### Exported Attributes
 
@@ -277,15 +287,15 @@ The following resources currently exist:
 
 ##### Parameters
 
-  * `name`      - *Required* -Name of the container.
-  * `config`    - *Optional* -Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
-  * `device`    - *Optional* -Device definition. See reference below.
+  * `name`      - *Required* - Name of the container.
+  * `config`    - *Optional* - Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
+  * `device`    - *Optional* - Device definition. See reference below.
 
 ##### Device Block
 
-  * `name`      - *Required* -Name of the device.
-  * `type`      - *Required* -Type of the device Must be one of none, disk, nic, unix-char, unix-block, usb, gpu.
-  * `properties`- *Required* -Map of key/value pairs of [device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration).
+  * `name`      - *Required* - Name of the device.
+  * `type`      - *Required* - Type of the device Must be one of none, disk, nic, unix-char, unix-block, usb, gpu.
+  * `properties`- *Required* - Map of key/value pairs of [device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration).
 
 ## Known Limitations
 

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -240,6 +240,30 @@ func TestAccContainer_removeDevice(t *testing.T) {
 	})
 }
 
+func TestAccContainer_fileUpload(t *testing.T) {
+	var container api.Container
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainer_fileUpload_1(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+				),
+			},
+			resource.TestStep{
+				Config: testAccContainer_fileUpload_2(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+				),
+			},
+		},
+	})
+}
+
 func testAccContainerRunning(t *testing.T, n string, container *api.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -559,6 +583,40 @@ resource "lxd_container" "container1" {
   name = "%s"
   image = "ubuntu"
   profiles = ["default"]
+}
+	`, name)
+}
+
+func testAccContainer_fileUpload_1(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "ubuntu"
+  profiles = ["default"]
+
+  file {
+    content = "Hello, World!\n"
+    target_file = "/tmp/foo/bar.txt"
+    mode = "0644"
+    create_directories = true
+  }
+}
+	`, name)
+}
+
+func testAccContainer_fileUpload_2(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "ubuntu"
+  profiles = ["default"]
+
+  file {
+    content = "Goodbye, World!\n"
+    target_file = "/tmp/foo/bar.txt"
+    mode = "0644"
+    create_directories = true
+  }
 }
 	`, name)
 }


### PR DESCRIPTION
This commit adds the file block to the lxd_container resource.
One or more individual files may be defined in the resource and
they will be uploaded/pushed to the container via the LXC/LXD API.

Updates to the files will cause all old files to be deleted and
new copies to be uploaded.