### PR TITLE
Add "refresh_interval" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ resource "lxd_snapshot" "snap1" {
   * `config_dir` - *Optional* - Directory path to client LXD configuration and certs. Defaults to `$HOME/.config/lxc`.
   * `generate_client_certificates` - *Optional* - Generate the LXC client's certificates if they don't exist. This can also be done out-of-band of Terraform with the lxc command-line client.
   * `accept_remote_certificate` - *Optional* - Accept the remote LXD server certificate. This can also be done out-of-band of Terraform with the lxc command-line client.
+  * `refresh_interval` - *Optional* - How often to poll during state changes. Defaults to `10s`.
 
 ### Resources
 

--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -1,10 +1,10 @@
 package lxd
 
 import (
-	"testing"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"os/exec"
+	"testing"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -15,12 +15,19 @@ func init() {
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"lxd": testAccProvider,
 	}
+
+	testAccProvider.ConfigureFunc = testProviderConfigureWrapper
 }
 
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func testProviderConfigureWrapper(d *schema.ResourceData) (interface{}, error) {
+	d.Set("refresh_interval", "5s")
+	return providerConfigure(d)
 }
 
 func TestProvider_impl(t *testing.T) {

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -151,6 +151,7 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 	var err error
 	client := meta.(*LxdProvider).Client
 	remote := meta.(*LxdProvider).Remote
+	refresh_interval := meta.(*LxdProvider).RefreshInterval
 
 	name := d.Get("name").(string)
 	ephem := d.Get("ephemeral").(bool)
@@ -193,7 +194,7 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 		Target:     []string{"Running"},
 		Refresh:    resourceLxdContainerRefresh(client, name),
 		Timeout:    3 * time.Minute,
-		Delay:      10 * time.Second,
+		Delay:      refresh_interval,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -338,6 +339,7 @@ func resourceLxdContainerUpdate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceLxdContainerDelete(d *schema.ResourceData, meta interface{}) (err error) {
 	client := meta.(*LxdProvider).Client
+	refresh_interval := meta.(*LxdProvider).RefreshInterval
 	name := d.Id()
 
 	ct, _ := client.ContainerState(name)
@@ -351,7 +353,7 @@ func resourceLxdContainerDelete(d *schema.ResourceData, meta interface{}) (err e
 			Target:     []string{"Stopped"},
 			Refresh:    resourceLxdContainerRefresh(client, name),
 			Timeout:    3 * time.Minute,
-			Delay:      10 * time.Second,
+			Delay:      refresh_interval,
 			MinTimeout: 3 * time.Second,
 		}
 


### PR DESCRIPTION
This lets you configure how aggressively the client polls the server for
state changes. If your containers start up very fast, you may want to
decrease this interval for a speed boost.