### PR TITLE
Allow image names with remote: prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 terraform-provider-lxd.iml
 .idea
 **/*.swp
+settings.json

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ resource "lxd_container" "test1" {
 }
 ```
 
-You can also launch a container directly from a remote image, not locally cached, by referencing the remote image name using the format:
- > `[remote:]image_alias|image_hash`
+You can also launch a container directly from a remote image, not locally cached, by referencing the remote image name using the format `[remote:]<image_alias|image_hash>`
 
 ```hcl
 resource "lxd_container" "test1" {
@@ -59,6 +58,16 @@ resource "lxd_container" "test1" {
   ephemeral = false
 }
 ```
+
+ > NOTE:
+ > Currently the only supported remotes are:
+ > * remote named defined in LXD provider (same as omitting `<remote>:` prefix)
+ > * `images`
+ > * `ubuntu`
+ > * `ubuntu-daily`
+ > See the LXD (https://linuxcontainers.org/lxd/getting-started-cli/#using-the-built-in-image-remotes)[documentation] for more info on default image remotes.
+
+#### Container Configuration & Devices
 
 A container can also take a number of configuration and device options. A full reference can be found [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md). For example, to create a container with 2 CPUs and to share the `/tmp` directory with the LXD host:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ resource "lxd_container" "test1" {
 }
 ```
 
+You can also launch a container directly from a remote image, not locally cached, by referencing the remote image name using the format:
+ > `[remote:]image_alias|image_hash`
+
+```hcl
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "images:ubuntu/xenial/amd64"
+  ephemeral = false
+}
+```
+
 A container can also take a number of configuration and device options. A full reference can be found [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md). For example, to create a container with 2 CPUs and to share the `/tmp` directory with the LXD host:
 
 ```hcl

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -135,11 +135,17 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
+	// Load static Public remotes
+	for k, v := range lxd.DefaultRemotes {
+		config.Remotes[k] = v
+	}
+
 	client, err := lxd.NewClient(&config, remote)
 	if err != nil {
 		err := fmt.Errorf("Could not create LXD client: %s", err)
 		return nil, err
 	}
+
 	log.Printf("[DEBUG] LXD Client: %#v", client)
 
 	if err := validateClient(client); err != nil {

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -155,6 +155,10 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 	name := d.Get("name").(string)
 	ephem := d.Get("ephemeral").(bool)
 	image := d.Get("image").(string)
+	if imgParts := strings.SplitN(image, ":", 2); len(imgParts) == 2 {
+		remote = imgParts[0]
+		image = imgParts[1]
+	}
 	config := resourceLxdConfigMap(d.Get("config"))
 	devices := resourceLxdDevices(d.Get("device"))
 

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -33,6 +33,25 @@ func TestAccContainer_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainer_remoteImage(t *testing.T) {
+	var container api.Container
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainer_remoteImage(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainer_config(t *testing.T) {
 	var container api.Container
 	containerName := strings.ToLower(petname.Generate(2, "-"))
@@ -617,6 +636,16 @@ resource "lxd_container" "container1" {
     mode = "0644"
     create_directories = true
   }
+}
+	`, name)
+}
+
+func testAccContainer_remoteImage(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:ubuntu/xenial/amd64"
+  profiles = ["default"]
 }
 	`, name)
 }


### PR DESCRIPTION
This PR allows a container to be launched using a remote image - without pre-caching the image.