### PR TITLE
Support to add a remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ To generate these files and store them in the LXD daemon, follow these [steps](h
 
 ```hcl
 provider "lxd" {
-  scheme  = "https"
-  address = "10.1.1.8"
-  remote  = "lxd-server"
+  scheme                       = "https"
+  address                      = "10.1.1.8"
+  remote                       = "lxd-server"
+  remote_password              = "password"
+  generate_client_certificates = true
+  accept_server_certificate    = true
 }
 ```
 
@@ -257,6 +260,8 @@ _note_: `local` and `remote` accept both IPv4 and IPv6 addresses.
   * `remote`   - *Optional* - Name of the remote LXD as it exists in the local lxc config. Defaults to `local`.
   * `remote_password` - *Optional* - Password of the remote LXD server.
   * `config_dir` - *Optional* - Directory path to client LXD configuration and certs. Defaults to `$HOME/.config/lxc`.
+  * `generate_client_certificates` - *Optional* - Generate the LXC client's certificates if they don't exist. This can also be done out-of-band of Terraform with the lxc command-line client.
+  * `accept_remote_certificate` - *Optional* - Accept the remote LXD server certificate. This can also be done out-of-band of Terraform with the lxc command-line client.
 
 ### Resources
 

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -57,7 +57,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Sensitive:   true,
 				Optional:    true,
-				Description: descriptions["lxc_remote_password"],
+				Description: descriptions["lxd_remote_password"],
 				DefaultFunc: schema.EnvDefaultFunc("LXD_REMOTE_PASSWORD", ""),
 			},
 
@@ -68,6 +68,20 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: func() (interface{}, error) {
 					return os.ExpandEnv("$HOME/.config/lxc"), nil
 				},
+			},
+
+			"generate_client_certificates": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: descriptions["lxd_generate_client_certs"],
+				DefaultFunc: schema.EnvDefaultFunc("LXD_GENERATE_CLIENT_CERTS", ""),
+			},
+
+			"accept_remote_certificate": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: descriptions["lxd_accept_remote_certificate"],
+				DefaultFunc: schema.EnvDefaultFunc("LXD_ACCEPT_SERVER_CERTIFICATE", ""),
 			},
 		},
 
@@ -85,12 +99,14 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"lxd_address":         "The FQDN or IP where the LXD daemon can be contacted. (default = /var/lib/lxd/unix.socket)",
-		"lxd_scheme":          "unix or https (default = unix)",
-		"lxd_port":            "Port LXD Daemon is listening on (default 8443).",
-		"lxd_remote":          "Name of the LXD remote. Required when lxd_scheme set to https, to enable locating server certificate.",
-		"lxd_remote_password": "The password for the remote.",
-		"lxd_config_dir":      "The directory to look for existing LXD configuration (default = $HOME/.config/lxc).",
+		"lxd_address":                      "The FQDN or IP where the LXD daemon can be contacted. (default = /var/lib/lxd/unix.socket)",
+		"lxd_scheme":                       "unix or https (default = unix)",
+		"lxd_port":                         "Port LXD Daemon is listening on (default 8443).",
+		"lxd_remote":                       "Name of the LXD remote. Required when lxd_scheme set to https, to enable locating server certificate.",
+		"lxd_remote_password":              "The password for the remote.",
+		"lxd_config_dir":                   "The directory to look for existing LXD configuration (default = $HOME/.config/lxc).",
+		"lxd_generate_client_certificates": "Automatically generate the LXD client certificates if they don't exist.",
+		"lxd_accept_remote_certificate":    "Accept the server certificate",
 	}
 }
 
@@ -118,13 +134,24 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Printf("[DEBUG] LXD Config: %#v", config)
 
 	if scheme == "https" {
-		// validate certifictes exist
+		// Validate the client certificates or try to generate them.
 		certf := config.ConfigPath("client.crt")
 		keyf := config.ConfigPath("client.key")
 		if !shared.PathExists(certf) || !shared.PathExists(keyf) {
-			err := fmt.Errorf("Certificate or key not found:\n\t%s\n\t%s", certf, keyf)
-			return nil, err
+			if v, ok := d.Get("generate_client_certificates").(bool); ok && v {
+				log.Printf("[DEBUG] Attempting to generate client certificates")
+				if err := shared.FindOrGenCert(certf, keyf, true); err != nil {
+					return nil, err
+				}
+			} else {
+				err := fmt.Errorf("Certificate or key not found:\n\t%s\n\t%s\n"+
+					"Either set generate_client_certs to true or generate the "+
+					"certificates out of band of Terraform and try again", certf, keyf)
+				return nil, err
+			}
 		}
+
+		// Validate the server certificate or try to add the remote server.
 		serverCertf := config.ServerCertPath(remote)
 		if !shared.PathExists(serverCertf) {
 			// If the server certificate was not found, try to add the remote.
@@ -170,23 +197,31 @@ func validateClient(client *lxd.Client) error {
 func addRemote(d *schema.ResourceData, config *lxd.Config) error {
 	// First, validate the client.
 	remote := d.Get("remote").(string)
-	c, err := lxd.NewClient(config, remote)
+	client, err := lxd.NewClient(config, remote)
 	if err != nil {
 		return err
 	}
 
 	// Check if the client is valid.
-	// Right now, this assumes PKI is in place by previous provisioning
-	// of client, server, and CA certificates.
-	// The LXC command-line client would prompt to accept a certificate
-	// if PKI was not in place.
-	_, err = c.GetServerConfig()
-	if err != nil {
-		return err
+	// If this passes, either the certificate was already accepted
+	// or the client is using PKI.
+	// If there is an error, attempt to accept the certificate.
+	if _, err = client.GetServerConfig(); err != nil {
+		if v, ok := d.Get("accept_remote_certificate").(bool); ok && v {
+			var err error
+			client, err = addServer(client, remote)
+			if err != nil {
+				return fmt.Errorf("Could not add the LXD server: %s", err)
+			}
+		} else {
+			return fmt.Errorf("Unable to communicate with remote. Either set " +
+				"accept_remote_certificate to true or add the remote out of band " +
+				"of Terraform and try again.")
+		}
 	}
 
 	// If the config is valid, check and see if the client is already trusted
-	if c.AmTrusted() {
+	if client.AmTrusted() {
 		log.Printf("[DEBUG] LXC client is trusted with %s", remote)
 		return nil
 	}
@@ -198,7 +233,7 @@ func addRemote(d *schema.ResourceData, config *lxd.Config) error {
 	}
 
 	log.Printf("[DEBUG] Attempting to authenticate with remote %s", remote)
-	_, err = clientDoUpdateMethod(c, "POST", "certificates", body, api.SyncResponse)
+	_, err = clientDoUpdateMethod(client, "POST", "certificates", body, api.SyncResponse)
 
 	if err != nil {
 		log.Printf("[DEBUG] Failed to authenticate with remote %s", remote)


### PR DESCRIPTION
This commit enables the LXD provider to add a remote if it has not
yet been added to the client configuration. This requires the user
to explicitly set accept_remote_certificate in the provider
configuration.

An option to generate the client certificates has also been added.