### PR TITLE
Add lxd_cached_image resource

### DIFF
--- a/lxd/resource_lxd_cached_image.go
+++ b/lxd/resource_lxd_cached_image.go
@@ -1,0 +1,270 @@
+package lxd
+
+import (
+	"fmt"
+	"log"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/lxc/lxd"
+)
+
+func resourceLxdCachedImage() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLxdCachedImageCreate,
+		Update: resourceLxdCachedImageUpdate,
+		Delete: resourceLxdCachedImageDelete,
+		Exists: resourceLxdCachedImageExists,
+		Read:   resourceLxdCachedImageRead,
+
+		Schema: map[string]*schema.Schema{
+
+			"aliases": {
+				Type:     schema.TypeList,
+				ForceNew: false,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"copy_aliases": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"source_image": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"source_remote": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			// Computed attributes
+
+			"architecture": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"copied_aliases": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceLxdCachedImageCreate(d *schema.ResourceData, meta interface{}) error {
+	dst := meta.(*LxdProvider).Client
+	remote := meta.(*LxdProvider).Remote
+	config := meta.(*LxdProvider).Config
+
+	srcName := d.Get("source_remote").(string)
+	src, err := lxd.NewClient(config, srcName)
+	if err != nil {
+		return err
+	}
+
+	image := d.Get("source_image").(string)
+	// has the user provided an fingerprint or alias?
+	aliasTarget := src.GetAlias(image)
+	if aliasTarget != "" {
+		image = aliasTarget
+	}
+
+	aliases := make([]string, 0)
+	if v, ok := d.GetOk("aliases"); ok {
+		for _, alias := range v.([]interface{}) {
+			// Check image alias doesn't already exist on destination
+			dstAliasTarget := dst.GetAlias(alias.(string))
+			if dstAliasTarget != "" {
+				return fmt.Errorf("Image alias already exists on destination: %s", alias.(string))
+			}
+
+			aliases = append(aliases, alias.(string))
+		}
+	}
+
+	// Get data about remote image, also checks it exists
+	imgInfo, err := src.GetImageInfo(image)
+	if err != nil {
+		return err
+	}
+
+	copyAliases := d.Get("copy_aliases").(bool)
+
+	// Execute the copy
+	err = src.CopyImage(image, dst, copyAliases, aliases, false, false, resourceLxdCachedImageCopyProgressHandler)
+	if err != nil {
+		return err
+	}
+
+	// Image was successfully copied, set resource ID
+	id := newCachedImageId(remote, imgInfo.Fingerprint)
+	d.SetId(id.resourceId())
+
+	// store remote aliases that we've copied, so we can filter them out later
+	copied := make([]string, 0)
+	if copyAliases {
+		for _, a := range imgInfo.Aliases {
+			copied = append(copied, a.Name)
+		}
+	}
+	d.Set("copied_aliases", copied)
+
+	return resourceLxdCachedImageRead(d, meta)
+}
+
+func resourceLxdCachedImageCopyProgressHandler(prog string) {
+	log.Println("[DEBUG] - image copy progress: ", prog)
+}
+
+func resourceLxdCachedImageUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+	id := newCachedImageIdFromResourceId(d.Id())
+
+	if d.HasChange("aliases") {
+		old, new := d.GetChange("aliases")
+		oldSet := buildSet(old.([]interface{}))
+		newSet := buildSet(new.([]interface{}))
+
+		// Delete removed
+		for _, a := range old.([]interface{}) {
+			alias := a.(string)
+			if _, ok := newSet[alias]; !ok {
+				client.DeleteAlias(alias)
+			}
+		}
+		// Add new
+		for _, a := range new.([]interface{}) {
+			alias := a.(string)
+			if _, ok := oldSet[alias]; !ok {
+				client.PostAlias(alias, "", id.fingerprint)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceLxdCachedImageDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+	id := newCachedImageIdFromResourceId(d.Id())
+
+	err := client.DeleteImage(id.fingerprint)
+
+	return err
+}
+
+func resourceLxdCachedImageExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*LxdProvider).Client
+	id := newCachedImageIdFromResourceId(d.Id())
+
+	_, err := client.GetImageInfo(id.fingerprint)
+	if err != nil {
+		if err.Error() == "not found" {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func resourceLxdCachedImageRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*LxdProvider).Client
+	id := newCachedImageIdFromResourceId(d.Id())
+
+	img, err := client.GetImageInfo(id.fingerprint)
+	if err != nil {
+		if err.Error() == "not found" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("fingerprint", id.fingerprint)
+	d.Set("source_remote", d.Get("source_remote"))
+	d.Set("copy_aliases", d.Get("copy_aliases"))
+	d.Set("architecture", img.Architecture)
+	d.Set("created_at", img.CreatedAt.Unix())
+
+	// Read aliases from img and set in resource data
+	// If the user has set 'copy_aliases' to true, then the
+	// locally cached image will have aliases set that aren't
+	// in the Terraform config.
+	// These need to be filtered out here so not to cause a diff.
+	var aliases []string
+	copiedSet := buildSet(d.Get("copied_aliases").([]interface{}))
+	configSet := buildSet(d.Get("aliases").([]interface{}))
+
+	for _, a := range img.Aliases {
+		_, inConfigSet := configSet[a.Name]
+		_, inCopySet := copiedSet[a.Name]
+
+		if inConfigSet || !inCopySet {
+			aliases = append(aliases, a.Name)
+		} else {
+			log.Println("[DEBUG] filtered alias ", a)
+		}
+	}
+	d.Set("aliases", aliases)
+
+	return nil
+}
+
+type cachedImageId struct {
+	remote      string
+	fingerprint string
+}
+
+func newCachedImageId(remote, fingerprint string) cachedImageId {
+	return cachedImageId{
+		remote:      remote,
+		fingerprint: fingerprint,
+	}
+}
+
+func newCachedImageIdFromResourceId(id string) cachedImageId {
+	parts := strings.SplitN(id, "/", 2)
+	return cachedImageId{
+		remote:      parts[0],
+		fingerprint: parts[1],
+	}
+}
+
+func (id cachedImageId) resourceId() string {
+	return fmt.Sprintf("%s/%s", id.remote, id.fingerprint)
+}
+
+// buildSet creates a map[string]bool from the give slice
+// the input slice is typed as []interface{} but a slice of strings is expected
+// any slice elements that are not a string will be silently dropped
+func buildSet(slice []interface{}) map[string]bool {
+	set := make(map[string]bool)
+	for _, v := range slice {
+		if s, ok := v.(string); ok {
+			set[s] = true
+		}
+	}
+	return set
+}

--- a/lxd/resource_lxd_cached_image_test.go
+++ b/lxd/resource_lxd_cached_image_test.go
@@ -1,0 +1,316 @@
+package lxd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"strconv"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+func TestAccCachedImage_basic(t *testing.T) {
+	var img api.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCachedImage_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img1", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img1", &img),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCachedImage_alias(t *testing.T) {
+	var img api.Image
+	alias1 := strings.ToLower(petname.Generate(2, "-"))
+	alias2 := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCachedImage_aliases(alias1, alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img2", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img2", &img),
+					testAccCachedImageContainsAlias(&img, alias1),
+					testAccCachedImageContainsAlias(&img, alias2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCachedImage_copiedAlias(t *testing.T) {
+	var img api.Image
+	alias1 := strings.ToLower(petname.Generate(2, "-"))
+	alias2 := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCachedImage_aliases2(alias1, alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img3", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img3", &img),
+					testAccCachedImageContainsAlias(&img, alias1),
+					testAccCachedImageContainsAlias(&img, alias2),
+					testAccCachedImageContainsAlias(&img, "alpine/3.5"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCachedImage_aliasCollision(t *testing.T) {
+	var img api.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCachedImage_aliasCollision(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img4", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img4", &img),
+					testAccCachedImageContainsAlias(&img, "alpine/3.5/amd64"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCachedImage_aliasAlreadyExists(t *testing.T) {
+	var img api.Image
+	alias := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCachedImage_aliasExists1(alias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.exists1", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.exists1", &img),
+					testAccCachedImageContainsAlias(&img, alias),
+				),
+			},
+			resource.TestStep{
+				Config:      testAccCachedImage_aliasExists2(alias),
+				ExpectError: regexp.MustCompile(`.*Image alias already exists on destination.*`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.exists1", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.exists1", &img),
+					testAccCachedImageContainsAlias(&img, alias),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCachedImage_addRemoveAlias(t *testing.T) {
+	var img api.Image
+	alias1 := strings.ToLower(petname.Generate(2, "-"))
+	alias2 := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCachedImage_aliases(alias1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img2", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img2", &img),
+					testAccCachedImageContainsAlias(&img, alias1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCachedImage_aliases(alias1, alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img2", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img2", &img),
+					testAccCachedImageContainsAlias(&img, alias1),
+					testAccCachedImageContainsAlias(&img, alias2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCachedImage_aliases(alias2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCachedImageExists(t, "lxd_cached_image.img2", &img),
+					resourceAccCachedImageCheckAttributes("lxd_cached_image.img2", &img),
+					testAccCachedImageContainsAlias(&img, alias2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCachedImageExists(t *testing.T, n string, image *api.Image) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found in state: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		id := newCachedImageIdFromResourceId(rs.Primary.ID)
+		client := testAccProvider.Meta().(*LxdProvider).Client
+		img, err := client.GetImageInfo(id.fingerprint)
+		if err != nil {
+			return err
+		}
+
+		if img != nil {
+			*image = *img
+			return nil
+		}
+
+		return fmt.Errorf("Image not found: %s", rs.Primary.ID)
+	}
+}
+
+func testAccCachedImageContainsAlias(img *api.Image, alias string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if img.Aliases == nil || len(img.Aliases) == 0 {
+			return fmt.Errorf("No aliases")
+		}
+
+		for _, a := range img.Aliases {
+			if a.Name != alias {
+				continue
+			}
+
+			if a.Name == alias {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Alias not found: %s", alias)
+	}
+}
+
+func resourceAccCachedImageCheckAttributes(n string, img *api.Image) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found in state: %s", n)
+		}
+
+		if rs.Primary.Attributes["architecture"] != img.Architecture {
+			return fmt.Errorf("architecture doesn't match")
+		}
+
+		if rs.Primary.Attributes["fingerprint"] != img.Fingerprint {
+			return fmt.Errorf("fingerprint doesn't match")
+		}
+
+		if rs.Primary.Attributes["created_at"] != strconv.FormatInt(img.CreatedAt.Unix(), 10) {
+			return fmt.Errorf("created_at doesn't match")
+		}
+
+		return nil
+
+	}
+}
+
+func testAccCachedImage_basic() string {
+	return fmt.Sprintf(`
+resource "lxd_cached_image" "img1" {
+  source_remote = "images"
+  source_image = "alpine/3.5"
+
+  copy_aliases = true
+}
+	`)
+}
+
+func testAccCachedImage_aliases(aliases ...string) string {
+	return fmt.Sprintf(`
+resource "lxd_cached_image" "img2" {
+  source_remote = "images"
+  source_image = "alpine/3.5/i386"
+
+  aliases = ["%s"]
+  copy_aliases = false
+}
+	`, strings.Join(aliases, `","`))
+}
+
+func testAccCachedImage_aliasExists1(alias string) string {
+	return fmt.Sprintf(`
+resource "lxd_cached_image" "exists1" {
+  source_remote = "images"
+  source_image = "alpine/3.5/i386"
+
+  aliases = ["%s"]
+  copy_aliases = false
+}
+	`, alias)
+}
+
+func testAccCachedImage_aliasExists2(alias string) string {
+	return fmt.Sprintf(`
+resource "lxd_cached_image" "exists1" {
+  source_remote = "images"
+  source_image = "alpine/3.5/i386"
+
+  aliases = ["%s"]
+  copy_aliases = false
+}
+
+resource "lxd_cached_image" "exists2" {
+  source_remote = "images"
+  source_image = "alpine/3.5/amd64"
+
+  aliases = ["%s"]
+  copy_aliases = false
+}
+	`, alias, alias)
+}
+
+func testAccCachedImage_aliases2(aliases ...string) string {
+	return fmt.Sprintf(`
+resource "lxd_cached_image" "img3" {
+  source_remote = "images"
+  source_image = "alpine/3.5"
+
+  aliases = ["alpine/3.5","%s"]
+  copy_aliases = true
+}
+	`, strings.Join(aliases, `","`))
+}
+
+func testAccCachedImage_aliasCollision() string {
+	return fmt.Sprintf(`
+resource "lxd_cached_image" "img4" {
+  source_remote = "images"
+  source_image = "alpine/3.5/amd64"
+
+  aliases = ["alpine/3.5/amd64"]
+  copy_aliases = true
+}
+	`)
+}


### PR DESCRIPTION
This adds the `lxd_cached_image` resource. It can used to manage local
copies of remote images, set aliases etc.

I've named it `lxd_cached_image` to distinguish it from a future
resource I'm planning to create, that will allow users to create an LXD
image from a tarball.