### PR TITLE
Multi remote LXD Provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_install:
 - sudo apt-get -qq update
 - sudo apt-get install -y lxd
 - sudo lxd init --auto
+- sudo lxc config set core.https_address "[::]"
+- sudo lxc config set core.trust_password $LXD_PASSWORD
+- sudo chmod -R 777 /home/travis/.config/lxc
 - sudo chmod 777 /var/lib/lxd/unix.socket
 - 'lxc image copy ubuntu:t local: --alias=ubuntu'
 - lxc image list

--- a/README.md
+++ b/README.md
@@ -20,18 +20,40 @@ Alternatively, the LXD Terraform provider can generate them on demand if `genera
 
 ### Example Configurations
 
-#### Provider (HTTPS)
+#### Provider (Use LXC Config)
+
+This is all that is needed if the LXD remotes have been defined out of band via the `lxc` client.
 
 ```hcl
 provider "lxd" {
-  scheme                       = "https"
-  address                      = "10.1.1.8"
-  remote                       = "lxd-server"
-  remote_password              = "password"
-  generate_client_certificates = true
-  accept_server_certificate    = true
 }
 ```
+
+#### Provider (Custom Remotes)
+
+If you're running `terraform` from a system where lxc is not installed then you can define all the remotes in the Provider config:
+
+```hcl
+provider "lxd" {
+  generate_client_certificates = true
+  accept_server_certificate    = true
+
+  lxd_remote {
+    name     = "lxd-server-1"
+    scheme   = "https"
+    address  = "10.1.1.8"
+    password = "password"
+  }
+
+  lxd_remote {
+    name     = "lxd-server-2"
+    scheme   = "https"
+    address  = "10.1.2.8"
+    password = "password"
+  }
+}
+```
+
 
 #### Basic Example
 
@@ -335,15 +357,20 @@ resource "lxd_snapshot" "snap1" {
 
 ##### Parameters
 
-  * `address`  - *Optional* - Unix socket file path or IP / FQDN where LXD daemon can be reached. Defaults to `/var/lib/lxd/unix.socket`
-  * `scheme`   - *Optional* - `https` or `unix`. Defaults to `unix`.
-  * `port`     - *Optional* - `https` scheme only - The port on which the LXD daemon is listening. Defaults to 8443.
-  * `remote`   - *Optional* - Name of the remote LXD as it exists in the local lxc config. Defaults to `local`.
-  * `remote_password` - *Optional* - Password of the remote LXD server.
   * `config_dir` - *Optional* - Directory path to client LXD configuration and certs. Defaults to `$HOME/.config/lxc`.
   * `generate_client_certificates` - *Optional* - Generate the LXC client's certificates if they don't exist. This can also be done out-of-band of Terraform with the lxc command-line client.
   * `accept_remote_certificate` - *Optional* - Accept the remote LXD server certificate. This can also be done out-of-band of Terraform with the lxc command-line client.
   * `refresh_interval` - *Optional* - How often to poll during state changes. Defaults to `10s`.
+
+
+The `lxd_remote` block supports:
+
+  * `address` - The IP address or hostname of the remote.
+  * `default` - `true` if this is this the default remote.
+  * `name` - The name of the LXD remote, that can be referenced in resource `remote` attributes.
+  * `port` - The port on which the LXD daemon is listening.
+  * `password` - The trust password configured on the LXD server.
+  * `scheme` - `https` or `unix`
 
 ### Resources
 
@@ -366,12 +393,14 @@ The following resources are currently available:
   * `source_image`  - *Required* - Fingerprint or alias of image to pull.
   * `aliases`       - *Optional* - A list of aliases to assign to the image after pulling.
   * `copy_aliases`  - *Optional* - True to copy the aliases of the image from the remote. Default = false.
+  * `remote`        - *Optional* - The remote in which the resource will be created. If it
+                                   is not provided, the default provider remote is used.
 
 ##### Exported Parameters
 
-  * `architecture` - The image architecture (e.g. amd64, i386).
-  * `created_at`   - The datetime of image creation, in Unix time.
-  * `fingerprint`  - The unique hash fingperint of the image.
+  * `architecture`   - The image architecture (e.g. amd64, i386).
+  * `created_at`     - The datetime of image creation, in Unix time.
+  * `fingerprint`    - The unique hash fingperint of the image.
   * `copied_aliases` - The list of aliases that were copied from the `source_image`.
 
 #### lxd_container
@@ -386,6 +415,8 @@ The following resources are currently available:
   * `config`    - *Optional* - Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
   * `device`    - *Optional* - Device definition. See reference below.
   * `file`      - *Optional* - File to upload to the container. See reference below.
+  * `remote`    - *Optional* - The remote in which the resource will be created. If it
+                               is not provided, the default provider remote is used.
 
 ##### Device Block
 
@@ -408,6 +439,8 @@ The following resources are currently available:
 
   * `name`      - *Required* - Name of the network. This is usually the device the network will appear as to containers.
   * `config`    - *Optional* - Map of key/value pairs of [network config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#network-configuration).
+  * `remote`    - *Optional* - The remote in which the resource will be created. If it
+                               is not provided, the default provider remote is used.
 
 ##### Exported Attributes
 
@@ -421,6 +454,8 @@ The following resources are currently available:
   * `name`      - *Required* - Name of the container.
   * `config`    - *Optional* - Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
   * `device`    - *Optional* - Device definition. See reference below.
+  * `remote`    - *Optional* - The remote in which the resource will be created. If it
+                               is not provided, the default provider remote is used.
 
 ##### Device Block
 
@@ -435,6 +470,8 @@ The following resources are currently available:
   * `name`   - *Required* - Name of the storage pool.
   * `driver` - *Required* - Storage Pool driver. Must be one of `dir`, `lvm`, `btrfs`, or `zfs`.
   * `config` - *Required* - Map of key/value pairs of [storage pool config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#storage-pool-configuration). Config settings vary from driver to driver.
+  * `remote` - *Optional* - The remote in which the resource will be created. If it
+                            is not provided, the default provider remote is used.
 
 #### lxd_volume
 
@@ -444,6 +481,8 @@ The following resources are currently available:
   * `pool`   - *Required* - The Storage Pool to host the volume.
   * `type`   - *Optional* - The "type" of volume. The default value is `custom`, which is the type to use for storage volumes attached to containers.
   * `config` - *Required* - Map of key/value pairs of [volume config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#storage-volume-configuration). Config settings vary depending on the Storage Pool used.
+  * `remote` - *Optional* - The remote in which the resource will be created. If it
+                            is not provided, the default provider remote is used.
 
 #### lxd_volume_container_attach
 
@@ -454,6 +493,8 @@ The following resources are currently available:
   * `container_name` - *Required* - Name of the container to attach the volume to.
   * `path`           - *Required* - Mountpoint of the volume in the container.
   * `device_name`    - *Optional* - The volume device name as seen by the container. By default, this will be the volume name.
+  * `remote`         - *Optional* - The remote in which the resource will be created. If it
+                                    is not provided, the default provider remote is used.
 
 #### lxd_snapshot
 
@@ -462,6 +503,8 @@ The following resources are currently available:
   * `name` - *Required* - Name of the snapshot.
   * `container_name` - *Required* - The name of the container to snapshot.
   * `stateful` - *Optional* - Set to `true` to create a stateful snapshot, `false` for stateless. Stateful snapshots include runtime state. Default = false
+  * `remote`   - *Optional* - The remote in which the resource will be created. If it
+                              is not provided, the default provider remote is used.
 
 ##### Exported Parameters
 

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -16,54 +17,131 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
+// LxdProvider contains the Provider configuration and initialized remote clients
 type LxdProvider struct {
-	Remote          string
-	Client          *lxd.Client
 	Config          *lxd.Config
 	RefreshInterval time.Duration
+
+	acceptRemoteCertificate bool
+	clientMap               map[string]*lxd.Client
 }
 
-// Provider returns a terraform.ResourceProvider.
+// InitClient creates and returns an LXD client for the named remote
+func (p *LxdProvider) initClient(remote string) (*lxd.Client, error) {
+	client, err := lxd.NewClient(p.Config, remote)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.clientMap == nil {
+		p.clientMap = make(map[string]*lxd.Client)
+	}
+
+	p.clientMap[remote] = client
+	return client, nil
+}
+
+// GetClient returns an LXD client for the named remote
+func (p *LxdProvider) GetClient(remote string) (*lxd.Client, error) {
+	if remote == "" {
+		remote = p.Config.DefaultRemote
+	}
+
+	if client, ok := p.clientMap[remote]; ok {
+		return client, nil
+	}
+
+	return p.initClient(remote)
+}
+
+// Provider returns a terraform.ResourceProvider
 func Provider() terraform.ResourceProvider {
 
-	// The actual provider
+	// The provider definition
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 
+			// I'd prefer to call this 'remote', however that was already used in the past
+			// to set the name of the root level LXD remote in the provider
+			// After an deprecation cycle we could rename this to 'remote'
+			"lxd_remote": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: descriptions["lxd_remote_address"],
+							Default:     "",
+						},
+
+						"default": &schema.Schema{
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: descriptions["lxd_remote_default"],
+						},
+
+						"name": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: descriptions["lxd_remote_name"],
+						},
+
+						"password": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: descriptions["lxd_remote_password"],
+						},
+
+						"port": &schema.Schema{
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: descriptions["lxd_remote_port"],
+							Default:     "8443",
+						},
+
+						"scheme": &schema.Schema{
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  descriptions["lxd_remote_scheme"],
+							ValidateFunc: validateLxdRemoteScheme,
+							Default:      "https",
+						},
+					},
+				},
+			},
+
 			"address": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: descriptions["lxd_address"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_ADDR", "/var/lib/lxd/unix.socket"),
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `lxd_remote.address` instead.",
 			},
 
 			"scheme": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: descriptions["lxd_scheme"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_SCHEME", "unix"),
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `lxd_remote.scheme` instead.",
 			},
 
 			"port": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: descriptions["lxd_port"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_PORT", "8443"),
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `lxd_remote.port` instead.",
 			},
 
 			"remote": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: descriptions["lxd_remote"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_REMOTE", "local"),
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `lxd_remote.name` instead.",
 			},
 
 			"remote_password": &schema.Schema{
-				Type:        schema.TypeString,
-				Sensitive:   true,
-				Optional:    true,
-				Description: descriptions["lxd_remote_password"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_REMOTE_PASSWORD", ""),
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+				Removed:   "Use `lxd_remote.password` instead.",
 			},
 
 			"config_dir": &schema.Schema{
@@ -116,115 +194,154 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"lxd_address":                      "The FQDN or IP where the LXD daemon can be contacted. (default = /var/lib/lxd/unix.socket)",
-		"lxd_scheme":                       "unix or https (default = unix)",
-		"lxd_port":                         "Port LXD Daemon is listening on (default 8443).",
-		"lxd_remote":                       "Name of the LXD remote. Required when lxd_scheme set to https, to enable locating server certificate.",
-		"lxd_remote_password":              "The password for the remote.",
-		"lxd_config_dir":                   "The directory to look for existing LXD configuration (default = $HOME/.config/lxc).",
-		"lxd_generate_client_certificates": "Automatically generate the LXD client certificates if they don't exist.",
 		"lxd_accept_remote_certificate":    "Accept the server certificate",
+		"lxd_config_dir":                   "The directory to look for existing LXD configuration. default = $HOME/.config/lxc",
+		"lxd_generate_client_certificates": "Automatically generate the LXD client certificates if they don't exist.",
 		"lxd_refresh_interval":             "How often to poll during state changes (default 10s)",
+		"lxd_remote_address":               "The FQDN or IP where the LXD daemon can be contacted. default = empty (read from lxc config)",
+		"lxd_remote_scheme":                "unix or https. default = unix",
+		"lxd_remote_port":                  "Port LXD Daemon API is listening on. default = 8443.",
+		"lxd_remote_name":                  "Name of the LXD remote. Required when lxd_scheme set to https, to enable locating server certificate.",
+		"lxd_remote_password":              "The password for the remote.",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	remote := d.Get("remote").(string)
-	scheme := d.Get("scheme").(string)
+	var config *lxd.Config
 
-	daemon_addr := ""
-	switch scheme {
-	case "unix":
-		daemon_addr = fmt.Sprintf("unix:%s", d.Get("address"))
-	case "https":
-		daemon_addr = fmt.Sprintf("https://%s:%s", d.Get("address"), d.Get("port"))
-	default:
-		err := fmt.Errorf("Invalid scheme: %s", scheme)
-		return nil, err
+	// Load remotes from LXC config
+	//
+	// This will not error if the `config_dir`` is not set, or LXC `config.yml`
+	// does not exist. The config reader will initialise the default config
+	// in this case, which includes the well-known public remotes and local
+	// unix socket remote.
+	configDir := d.Get("config_dir").(string)
+	configPath := os.ExpandEnv(path.Join(configDir, "config.yml"))
+	if conf, err := lxd.LoadConfig(configPath); err != nil {
+		return nil, fmt.Errorf("Could not read the lxc config: [%s]. Error: %s", configPath, err)
+	} else {
+		delete(conf.Remotes, "local")
+		config = conf
 	}
 
-	// build LXD config
-	config := &lxd.Config{
-		ConfigDir: d.Get("config_dir").(string),
-		Remotes:   make(map[string]lxd.RemoteConfig),
+	refreshInterval := d.Get("refresh_interval").(string)
+	if refreshInterval == "" {
+		refreshInterval = "10s"
 	}
-	config.Remotes[remote] = lxd.RemoteConfig{Addr: daemon_addr}
-
-	// Load static Public remotes
-	for k, v := range lxd.DefaultRemotes {
-		config.Remotes[k] = v
-	}
-	log.Printf("[DEBUG] LXD Config: %#v", config)
-
-	// Build a basic client
-	client, err := lxd.NewClient(config, remote)
-	if err != nil {
-		err := fmt.Errorf("Could not create LXD client: %s", err)
-		return nil, err
-	}
-
-	if scheme == "https" {
-		// Validate the client certificates or try to generate them.
-		if err := validateClientCerts(d, *config); err != nil {
-			return nil, err
-		}
-
-		// Validate the server certificate or try to add the remote server.
-		serverCertf := config.ServerCertPath(remote)
-		if !shared.PathExists(serverCertf) {
-			// Check if PKI is in use by validating a client
-			if err := validateClient(client); err != nil {
-				// PKI probably isn't in use. Try to add the remote certificate.
-				if v, ok := d.Get("accept_remote_certificate").(bool); ok && v {
-					if err := getRemoteCertificate(client, remote); err != nil {
-						return nil, fmt.Errorf("Could get remote certificate: %s", err)
-					}
-				} else {
-					return nil, fmt.Errorf("Unable to communicate with remote. Either set " +
-						"accept_remote_certificate to true or add the remote out of band " +
-						"of Terraform and try again.")
-				}
-			}
-		}
-
-		// Finally, make sure the client is authenticated.
-		// A new client must be created, or there will be a certificate error.
-		client, err = lxd.NewClient(config, remote)
-		if err != nil {
-			return nil, err
-		}
-		if err := checkClientAuth(d, client); err != nil {
-			return nil, err
-		}
-	}
-
-	// Final client configuration
-	log.Printf("[DEBUG] LXD Client: %#v", client)
-
-	// Make sure it's valid before proceeding
-	if err := validateClient(client); err != nil {
-		return nil, err
-	}
-
-	refresh_interval := d.Get("refresh_interval").(string)
-	if refresh_interval == "" {
-		refresh_interval = "10s"
-	}
-	refresh_interval_parsed, err := time.ParseDuration(refresh_interval)
+	refreshIntervalParsed, err := time.ParseDuration(refreshInterval)
 	if err != nil {
 		return nil, err
+	}
+
+	acceptRemoteCertificate := false
+	if v, ok := d.Get("accept_remote_certificate").(bool); ok && v {
+		acceptRemoteCertificate = true
 	}
 
 	lxdProv := LxdProvider{
-		Remote:          remote,
-		Client:          client,
-		Config:          config,
-		RefreshInterval: refresh_interval_parsed,
+		Config:                  config,
+		RefreshInterval:         refreshIntervalParsed,
+		acceptRemoteCertificate: acceptRemoteCertificate,
 	}
+
+	// Validate the client certificates or try to generate them.
+	if err := validateClientCerts(d, *config); err != nil {
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] LXD Config: %#v", config)
+
+	// Create remote from Environment variables (if defined)
+	envRemote := map[string]interface{}{
+		"name":     os.Getenv("LXD_REMOTE"),
+		"address":  os.Getenv("LXD_ADDR"),
+		"port":     os.Getenv("LXD_PORT"),
+		"password": os.Getenv("LXD_PASSWORD"),
+		"scheme":   os.Getenv("LXD_SCHEME"),
+		"default":  true,
+	}
+	err = lxdProv.providerConfigureClient(envRemote)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create client for remote [%s]: %s", envRemote["name"].(string), err)
+	}
+
+	// Loop over LXD Remotes defined in provider and initialise
+	for _, rem := range d.Get("lxd_remote").([]interface{}) {
+		lxdRemote := rem.(map[string]interface{})
+		err := lxdProv.providerConfigureClient(lxdRemote)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to create client for remote [%s]: %s", lxdRemote["name"].(string), err)
+		}
+	}
+
+	log.Printf("[DEBUG] LXD Provider: %#v", lxdProv)
 
 	return &lxdProv, nil
 }
 
+func (p *LxdProvider) providerConfigureClient(lxdRemote map[string]interface{}) error {
+	name := lxdRemote["name"].(string)
+	scheme := lxdRemote["scheme"].(string)
+	port := lxdRemote["port"].(string)
+	password := lxdRemote["password"].(string)
+
+	if addr, ok := lxdRemote["address"]; ok {
+		daemonAddr := ""
+		switch scheme {
+		case "unix", "":
+			daemonAddr = fmt.Sprintf("unix:%s", addr)
+		case "https":
+			daemonAddr = fmt.Sprintf("https://%s:%s", addr, port)
+		}
+
+		p.Config.Remotes[name] = lxd.RemoteConfig{Addr: daemonAddr}
+
+		if lxdRemote["default"].(bool) {
+			p.Config.DefaultRemote = lxdRemote["name"].(string)
+		}
+
+		if scheme == "https" {
+			rclient, err := lxd.NewClient(p.Config, name)
+
+			// Validate the server certificate or try to add the remote server.
+			serverCertf := p.Config.ServerCertPath(name)
+			if !shared.PathExists(serverCertf) {
+				// Check if PKI is in use by validating a client
+				if err := validateClient(rclient); err != nil {
+					// PKI probably isn't in use. Try to add the remote certificate.
+					if p.acceptRemoteCertificate {
+						if err := getRemoteCertificate(rclient, name); err != nil {
+							return fmt.Errorf("Could get remote certificate: %s", err)
+						}
+					} else {
+						return fmt.Errorf("Unable to communicate with remote. Either set " +
+							"accept_remote_certificate to true or add the remote out of band " +
+							"of Terraform and try again.")
+					}
+				}
+			}
+
+			// Finally, make sure the client is authenticated.
+			// A new client must be created, or there will be a certificate error.
+			// rclient, err = lxd.NewClient(p.Config, name)
+			rclient, err = p.initClient(name)
+			if err != nil {
+				return err
+			}
+			if err := checkClientAuth(name, password, rclient); err != nil {
+				return err
+			}
+			// Make sure it's valid before proceeding
+			if err := validateClient(rclient); err != nil {
+				return err
+			}
+
+		}
+	}
+	return nil
+}
+
+// validateClient makes a simple GET request to the servers API
 func validateClient(client *lxd.Client) error {
 	if _, err := client.GetServerConfig(); err != nil {
 		return err
@@ -232,6 +349,8 @@ func validateClient(client *lxd.Client) error {
 	return nil
 }
 
+// validateClientCerts checks if LXD client certificate & key already exist on disk
+// if not and if 'generate_client_certificates' = true it will generate them
 func validateClientCerts(d *schema.ResourceData, config lxd.Config) error {
 	certf := config.ConfigPath("client.crt")
 	keyf := config.ConfigPath("client.key")
@@ -243,7 +362,7 @@ func validateClientCerts(d *schema.ResourceData, config lxd.Config) error {
 			}
 		} else {
 			err := fmt.Errorf("Certificate or key not found:\n\t%s\n\t%s\n"+
-				"Either set generate_client_certs to true or generate the "+
+				"Either set generate_client_certificates to true or generate the "+
 				"certificates out of band of Terraform and try again", certf, keyf)
 			return err
 		}
@@ -301,19 +420,41 @@ func getRemoteCertificate(client *lxd.Client, remote string) error {
 	return nil
 }
 
-func checkClientAuth(d *schema.ResourceData, client *lxd.Client) error {
-	remote := d.Get("remote").(string)
+func checkClientAuth(remoteName, remotePassword string, client *lxd.Client) error {
+	log.Printf("[DEBUG] Checking client is authenticated for remote: %s", remoteName)
+
 	if client.AmTrusted() {
-		log.Printf("[DEBUG] LXC client is trusted with %s", remote)
+		log.Printf("[DEBUG] LXC client is trusted with %s", remoteName)
 		return nil
 	}
 
-	remotePassword := d.Get("remote_password").(string)
 	if err := client.AddMyCertToServer(remotePassword); err != nil {
 		return fmt.Errorf("Unable to authenticate with remote server: %s", err)
 	}
 
-	log.Printf("[DEBUG] Successfully authenticated with remote %s", remote)
+	log.Printf("[DEBUG] Successfully authenticated with remote %s", remoteName)
 
 	return nil
+}
+
+// selectRemote is a convenience method that returns the 'remote' set
+// in the LXD resource or the default remote configured on the Provider
+func (p *LxdProvider) selectRemote(d *schema.ResourceData) string {
+	var remote string
+	if rem, ok := d.GetOk("remote"); ok && rem != "" {
+		remote = rem.(string)
+	} else {
+		remote = p.Config.DefaultRemote
+	}
+	return remote
+}
+
+// validateLxdRemoteScheme validates the `lxd_remote.scheme` configuration
+// value as parse time
+func validateLxdRemoteScheme(v interface{}, k string) ([]string, []error) {
+	scheme := v.(string)
+	if scheme != "https" && scheme != "unix" {
+		return nil, []error{fmt.Errorf("Invalid LXD Remote scheme: %s", scheme)}
+	}
+	return nil, nil
 }

--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -1,10 +1,23 @@
 package lxd
 
 import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"fmt"
+
+	"io/ioutil"
+
+	"path/filepath"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"os/exec"
-	"testing"
+	"github.com/lxc/lxd"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -12,6 +25,8 @@ var testAccProvider *schema.Provider
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
+	testAccProvider.ResourcesMap["lxd_noop"] = resourceLxdNoOp()
+
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"lxd": testAccProvider,
 	}
@@ -34,9 +49,221 @@ func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
 }
 
+func TestAccLxdProvider_envRemote(t *testing.T) {
+	envName := os.Getenv("LXD_REMOTE")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccLxdProvider_basic(envName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", envName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLxdProvider_imageRemotes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccLxdProvider_basic("ubuntu"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", "ubuntu"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccLxdProvider_basic("ubuntu-daily"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", "ubuntu-daily"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccLxdProvider_basic("images"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", "images"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLxdProvider_lxcConfigRemotes(t *testing.T) {
+	remoteName := strings.ToLower(petname.Generate(2, "-"))
+	remoteAddr := os.Getenv("LXD_ADDR")
+	remotePort := os.Getenv("LXD_PORT")
+	remotePassword := os.Getenv("LXD_PASSWORD")
+
+	tmpDirName := petname.Generate(1, "")
+	tmpDir, err := ioutil.TempDir(os.TempDir(), tmpDirName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir) // clean up
+
+	conf := &lxd.Config{}
+	conf.Remotes = map[string]lxd.RemoteConfig{
+		remoteName: {
+			Addr: fmt.Sprintf("%s://%s:%s", os.Getenv("LXD_SCHEME"), os.Getenv("LXD_ADDR"), os.Getenv("LXD_PORT")),
+		},
+	}
+	conf.DefaultRemote = remoteName
+	lxd.SaveConfig(conf, filepath.Join(tmpDir, "config.yml"))
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccLxdProvider_lxcConfig1(tmpDir, remoteName, remoteAddr, remotePort, remotePassword),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", remoteName),
+				),
+			},
+			resource.TestStep{
+				Config: testAccLxdProvider_lxcConfig2(tmpDir, remoteName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", remoteName),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccLxdProvider_providerRemote(t *testing.T) {
+	envName := strings.ToLower(petname.Generate(2, "-"))
+	envPort := os.Getenv("LXD_PORT")
+	envAddr := os.Getenv("LXD_ADDR")
+	envPassword := os.Getenv("LXD_PASSWORD")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccLxdProvider_remote(envName, envAddr, envPort, envPassword),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_noop.noop1", "remote", envName),
+				),
+			},
+		},
+	})
+}
+
 func testAccPreCheck(t *testing.T) {
 	cmd := exec.Command("lxc", "--version")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("LXD client must be available: %s", err)
+	}
+}
+
+func testAccLxdProvider_basic(remote string) string {
+	return fmt.Sprintf(`
+provider "lxd" {
+}
+
+resource "lxd_noop" "noop1" {
+	name = "noop1"
+	remote = "%s"
+}
+`, remote)
+}
+
+func testAccLxdProvider_remote(remote, addr, port, password string) string {
+	return fmt.Sprintf(`
+provider "lxd" {
+	accept_remote_certificate    = true
+	generate_client_certificates = true
+	lxd_remote {
+		name     = "%s"
+		address  = "%s"
+		port     = "%s"
+		password = "%s"
+	}
+}
+
+resource "lxd_noop" "noop1" {
+	name = "noop1"
+	remote = "%s"
+}
+`, remote, addr, port, password, remote)
+}
+
+func testAccLxdProvider_lxcConfig1(confDir, remote, addr, port, password string) string {
+	return fmt.Sprintf(`
+provider "lxd" {
+	config_dir                   = "%s"
+	accept_remote_certificate    = true
+	generate_client_certificates = true
+	lxd_remote {
+		name     = "%s"
+		address  = "%s"
+		port     = "%s"
+		password = "%s"
+	}
+}
+
+resource "lxd_noop" "noop1" {
+	name = "noop1"
+	remote = "%s"
+}
+`, confDir, remote, addr, port, password, remote)
+}
+
+func testAccLxdProvider_lxcConfig2(confDir, remote string) string {
+
+	return fmt.Sprintf(`
+provider "lxd" {
+	config_dir = "%s"
+	accept_remote_certificate = true
+	generate_client_certificates = true
+}
+
+resource "lxd_noop" "noop1" {
+	name = "noop1"
+	remote = "%s"
+}
+`, confDir, remote)
+}
+
+// this NoOp resources allows us to invoke the Terraform testing framework to test the Provider
+// without actually calling out to any LXD server's to create or destroy resources.
+func resourceLxdNoOp() *schema.Resource {
+	return &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error {
+			client, err := meta.(*LxdProvider).GetClient(d.Get("remote").(string))
+			if err != nil {
+				return err
+			}
+
+			d.SetId(d.Get("name").(string))
+			d.Set("name", d.Get("name"))
+			d.Set("remote", client.Name)
+			return nil
+		},
+		Delete: func(d *schema.ResourceData, meta interface{}) error {
+			d.SetId("")
+			return nil
+		},
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			d.Set("name", d.Get("name"))
+			return nil
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"remote": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Default:  "",
+			},
+		},
 	}
 }

--- a/lxd/resource_lxd_cached_image_test.go
+++ b/lxd/resource_lxd_cached_image_test.go
@@ -177,7 +177,10 @@ func testAccCachedImageExists(t *testing.T, n string, image *api.Image) resource
 		}
 
 		id := newCachedImageIdFromResourceId(rs.Primary.ID)
-		client := testAccProvider.Meta().(*LxdProvider).Client
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
 		img, err := client.GetImageInfo(id.fingerprint)
 		if err != nil {
 			return err

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -294,7 +294,10 @@ func testAccContainerRunning(t *testing.T, n string, container *api.Container) r
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testAccProvider.Meta().(*LxdProvider).Client
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
 		ct, err := client.ContainerInfo(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -36,12 +36,23 @@ func resourceLxdNetwork() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
+			"remote": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "",
+			},
 		},
 	}
 }
 
 func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
 
 	name := d.Get("name").(string)
 	config := resourceLxdConfigMap(d.Get("config"))
@@ -61,7 +72,11 @@ func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLxdNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
 	name := d.Id()
 
 	network, err := client.NetworkGet(name)
@@ -84,7 +99,12 @@ func resourceLxdNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLxdNetworkDelete(d *schema.ResourceData, meta interface{}) (err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	if err = client.NetworkDelete(name); err != nil {
@@ -95,7 +115,12 @@ func resourceLxdNetworkDelete(d *schema.ResourceData, meta interface{}) (err err
 }
 
 func resourceLxdNetworkExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return false, err
+	}
+
 	name := d.Id()
 
 	exists = false

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -75,7 +75,10 @@ func testAccNetworkExists(t *testing.T, n string, network *api.Network) resource
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testAccProvider.Meta().(*LxdProvider).Client
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
 		n, err := client.NetworkGet(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -57,12 +57,23 @@ func resourceLxdProfile() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"remote": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Default:  "",
+			},
 		},
 	}
 }
 
 func resourceLxdProfileCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
 
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
@@ -89,7 +100,12 @@ func resourceLxdProfileCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLxdProfileRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	profile, err := client.ProfileConfig(name)
@@ -107,7 +123,12 @@ func resourceLxdProfileRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLxdProfileUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	var changed bool
@@ -160,7 +181,12 @@ func resourceLxdProfileUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLxdProfileDelete(d *schema.ResourceData, meta interface{}) (err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	if err = client.ProfileDelete(name); err != nil {
@@ -171,7 +197,12 @@ func resourceLxdProfileDelete(d *schema.ResourceData, meta interface{}) (err err
 }
 
 func resourceLxdProfileExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return false, err
+	}
+
 	name := d.Id()
 
 	exists = false

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -234,7 +234,10 @@ func testAccProfileRunning(t *testing.T, n string, profile *api.Profile) resourc
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testAccProvider.Meta().(*LxdProvider).Client
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
 		p, err := client.ProfileConfig(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -41,12 +41,24 @@ func resourceLxdStoragePool() *schema.Resource {
 				Required: true,
 				ForceNew: false,
 			},
+
+			"remote": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Default:  "",
+			},
 		},
 	}
 }
 
 func resourceLxdStoragePoolCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Get("name").(string)
 	driver := d.Get("driver").(string)
 	config := resourceLxdConfigMap(d.Get("config"))
@@ -62,7 +74,12 @@ func resourceLxdStoragePoolCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceLxdStoragePoolRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	pool, err := client.StoragePoolGet(name)
@@ -78,7 +95,12 @@ func resourceLxdStoragePoolRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceLxdStoragePoolUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	if d.HasChange("config") {
@@ -101,7 +123,12 @@ func resourceLxdStoragePoolUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceLxdStoragePoolDelete(d *schema.ResourceData, meta interface{}) (err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	name := d.Id()
 
 	if err = client.StoragePoolDelete(name); err != nil {
@@ -112,7 +139,12 @@ func resourceLxdStoragePoolDelete(d *schema.ResourceData, meta interface{}) (err
 }
 
 func resourceLxdStoragePoolExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return false, err
+	}
+
 	name := d.Id()
 	exists = false
 

--- a/lxd/resource_lxd_storage_pool_test.go
+++ b/lxd/resource_lxd_storage_pool_test.go
@@ -45,7 +45,10 @@ func testAccStoragePoolExists(t *testing.T, n string, pool *api.StoragePool) res
 
 		poolName := rs.Primary.ID
 
-		client := testAccProvider.Meta().(*LxdProvider).Client
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
 		v, err := client.StoragePoolGet(poolName)
 		if err != nil {
 			return err

--- a/lxd/resource_lxd_volume_container_attach.go
+++ b/lxd/resource_lxd_volume_container_attach.go
@@ -47,12 +47,24 @@ func resourceLxdVolumeContainerAttach() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			"remote": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Default:  "",
+			},
 		},
 	}
 }
 
 func resourceLxdVolumeContainerAttachCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	pool := d.Get("pool").(string)
 	volumeName := d.Get("volume_name").(string)
 	containerName := d.Get("container_name").(string)
@@ -97,7 +109,12 @@ func resourceLxdVolumeContainerAttachCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceLxdVolumeContainerAttachRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	v := NewVolumeAttachmentIdFromResourceId(d.Id())
 
 	deviceName, deviceInfo, err := resourceLxdVolumeContainerAttachedVolume(client, v)
@@ -115,7 +132,12 @@ func resourceLxdVolumeContainerAttachRead(d *schema.ResourceData, meta interface
 }
 
 func resourceLxdVolumeContainerAttachDelete(d *schema.ResourceData, meta interface{}) (err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return err
+	}
+
 	v := NewVolumeAttachmentIdFromResourceId(d.Id())
 	deviceName := d.Get("device_name").(string)
 
@@ -141,7 +163,12 @@ func resourceLxdVolumeContainerAttachDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceLxdVolumeContainerAttachExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
-	client := meta.(*LxdProvider).Client
+	p := meta.(*LxdProvider)
+	client, err := p.GetClient(p.selectRemote(d))
+	if err != nil {
+		return false, err
+	}
+
 	v := NewVolumeAttachmentIdFromResourceId(d.Id())
 	exists = false
 

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -67,8 +67,11 @@ func testAccVolumeContainerAttachExists(t *testing.T, n string) resource.TestChe
 		}
 
 		v := NewVolumeAttachmentIdFromResourceId(rs.Primary.ID)
-		client := testAccProvider.Meta().(*LxdProvider).Client
-		_, _, err := resourceLxdVolumeContainerAttachedVolume(client, v)
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
+		_, _, err = resourceLxdVolumeContainerAttachedVolume(client, v)
 		if err != nil {
 			return err
 		}

--- a/lxd/resource_lxd_volume_test.go
+++ b/lxd/resource_lxd_volume_test.go
@@ -45,7 +45,10 @@ func testAccVolumeExists(t *testing.T, n string, volume *api.StorageVolume) reso
 		}
 
 		v := NewVolumeIdFromResourceId(rs.Primary.ID)
-		client := testAccProvider.Meta().(*LxdProvider).Client
+		client, err := testAccProvider.Meta().(*LxdProvider).GetClient("")
+		if err != nil {
+			return err
+		}
 		vol, err := client.StoragePoolVolumeTypeGet(v.pool, v.name, v.volType)
 		if err != nil {
 			return err


### PR DESCRIPTION
**Breaking Change**

This adds the following the following features:
- LXD Provider now reads remotes from LXC config file
- Multiple remotes can be specified as `lxd_remote` resources in the Provider
Remove redundant test code