### PR TITLE
Fix #59 - out of band default LXD remote is ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,6 @@ resource "lxd_container" "test1" {
 ```
 
  > NOTE:
- > Currently only the following remotes are supported for pulling images:
- > * `images`
- > * `ubuntu`
- > * `ubuntu-daily`
- > * remote named defined in LXD provider (same as omitting `<remote>:` prefix from `lxd_container` image attribute)
- > 
  > See the LXD [documentation](https://linuxcontainers.org/lxd/getting-started-cli/#using-the-built-in-image-remotes) for more info on default image remotes.
 
 #### Container Configuration & Devices
@@ -357,20 +351,36 @@ resource "lxd_snapshot" "snap1" {
 
 ##### Parameters
 
-  * `config_dir` - *Optional* - Directory path to client LXD configuration and certs. Defaults to `$HOME/.config/lxc`.
-  * `generate_client_certificates` - *Optional* - Generate the LXC client's certificates if they don't exist. This can also be done out-of-band of Terraform with the lxc command-line client.
-  * `accept_remote_certificate` - *Optional* - Accept the remote LXD server certificate. This can also be done out-of-band of Terraform with the lxc command-line client.
-  * `refresh_interval` - *Optional* - How often to poll during state changes. Defaults to `10s`.
-
+  * `config_dir`                   - *Optional* - Directory path to client LXD configuration and certs. Defaults to `$HOME/.config/lxc`.
+  * `generate_client_certificates` - *Optional* - Generate the LXC client's certificates if they don't exist. 
+                                     This can also be done out-of-band of Terraform with the lxc command-line client.
+  * `accept_remote_certificate`    - *Optional* - Accept the remote LXD server certificate. 
+                                     This can also be done out-of-band of Terraform with the lxc command-line client.
+  * `refresh_interval`             - *Optional* - How often to poll during state changes. Defaults to `10s`.
 
 The `lxd_remote` block supports:
 
-  * `address` - The IP address or hostname of the remote.
-  * `default` - `true` if this is this the default remote.
-  * `name` - The name of the LXD remote, that can be referenced in resource `remote` attributes.
-  * `port` - The port on which the LXD daemon is listening.
-  * `password` - The trust password configured on the LXD server.
-  * `scheme` - `https` or `unix`
+  * `address`  - *Required* - The IP address or hostname of the remote.
+  * `name`     - *Required* - The name of the LXD remote, that can be referenced in resource `remote` attributes.
+  * `default`  - *Optional* - `true` if this is this the default remote. Default = `false`.
+  * `port`     - *Optional* - The port on which the LXD daemon is listening. Default = `8443`.
+  * `password` - *Optional* - The trust password configured on the LXD server.
+  * `scheme`   - *Optional* - `https` or `unix`. Default = `https`.
+
+The LXD Provider can also be configured via environment variables.
+
+  * `LXD_REMOTE`   - Equivalent to `lxd_remote.name`
+  * `LXD_ADDR`     - Equivalent to `lxd_remote.address`
+  * `LXD_PORT`     - Equivalent to `lxd_remote.port`
+  * `LXD_PASSWORD` - Equivalent to `lxd_remote.password`
+  * `LXD_SCHEME`   - Equivalent to `lxd_remote.scheme`
+
+##### The Default remote
+
+> The provider uses the following order of preference to determine the *Default* LXD remote:
+>  1. the `lxd_remote` block with attribute `default` set to true
+>  2. the remote defined via environment variables (`LXD_REMOTE`, `LXD_ADDR` etc.)
+>  3. the remote set in `lxc` config file that is marked as default
 
 ### Resources
 

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -260,9 +260,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		"scheme":   os.Getenv("LXD_SCHEME"),
 		"default":  true,
 	}
-	err = lxdProv.providerConfigureClient(envRemote)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to create client for remote [%s]: %s", envRemote["name"].(string), err)
+	if envRemote["name"] != "" {
+		err = lxdProv.providerConfigureClient(envRemote)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to create client for remote [%s]: %s", envRemote["name"].(string), err)
+		}
 	}
 
 	// Loop over LXD Remotes defined in provider and initialise

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -219,7 +219,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if conf, err := lxd.LoadConfig(configPath); err != nil {
 		return nil, fmt.Errorf("Could not read the lxc config: [%s]. Error: %s", configPath, err)
 	} else {
-		delete(conf.Remotes, "local")
 		config = conf
 	}
 
@@ -260,6 +259,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		"scheme":   os.Getenv("LXD_SCHEME"),
 		"default":  true,
 	}
+	// LXD_REMOTE must be set, or we ignore all the rest of the env vars
 	if envRemote["name"] != "" {
 		err = lxdProv.providerConfigureClient(envRemote)
 		if err != nil {


### PR DESCRIPTION
Fixes #59

This commit fixes an issue, where the default provider is ignored If the lxc client has been configured out of band.