### PR TITLE
Use the default profile by default

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -48,9 +48,10 @@ func resourceLxdContainer() *schema.Resource {
 
 			"profiles": &schema.Schema{
 				Type:     schema.TypeList,
-				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 
 			"device": &schema.Schema{
@@ -183,6 +184,11 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
+	// If no profiles were set, use the default profile
+	if len(profiles) == 0 {
+		profiles = append(profiles, "default")
+	}
+
 	// client.Init = (name string, imgremote string, image string, profiles *[]string, config map[string]string, devices shared.Devices, ephem bool)
 	var resp *api.Response
 	if resp, err = client.Init(name, remote, image, &profiles, config, devices, ephem); err != nil {
@@ -270,6 +276,9 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 		"type": "ssh",
 		"host": sshIP,
 	})
+
+	// Set the profiles used by the container
+	d.Set("profiles", container.Profiles)
 
 	return nil
 }

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -279,6 +279,26 @@ func TestAccContainer_fileUpload(t *testing.T) {
 	})
 }
 
+func TestAccContainer_defaultProfile(t *testing.T) {
+	var container api.Container
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainer_defaultProfile(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_container.container1", "profiles.0", "default"),
+					testAccContainerProfile(&container, "default"),
+				),
+			},
+		},
+	})
+}
+
 func testAccContainerRunning(t *testing.T, n string, container *api.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -645,6 +665,15 @@ resource "lxd_container" "container1" {
   name = "%s"
   image = "images:ubuntu/xenial/amd64"
   profiles = ["default"]
+}
+	`, name)
+}
+
+func testAccContainer_defaultProfile(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "ubuntu"
 }
 	`, name)
 }


### PR DESCRIPTION
This commit configures containers to use the default profile
when a profile was not specified. It also makes the profile
attribute "computed" so the implicitly added "default" profile
is stored in the Terraform state.

For #60 