### PR TITLE
Allow update of container limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ resource "lxd_container" "test1" {
 
 #### Container Configuration & Devices
 
-A container can also take a number of configuration and device options. A full reference can be found [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md). For example, to create a container with 2 CPUs and to share the `/tmp` directory with the LXD host:
+A container can also take a number of configuration and device options. A full reference can be found [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md). For example, to create an autostart container with 2 CPUs and to share the `/tmp` directory with the LXD host:
 
 ```hcl
 resource "lxd_container" "test1" {
@@ -99,7 +99,11 @@ resource "lxd_container" "test1" {
   ephemeral = false
 
   config {
-    limits.cpu = 2
+    boot.autostart = true
+  }
+
+  limits {
+    cpu = 2
   }
 
   device {
@@ -113,6 +117,8 @@ resource "lxd_container" "test1" {
   }
 }
 ```
+
+Note, the `config` attributes cannot be changed without destroying and re-creating the container, however values in `limits` can be changed on the fly.
 
 #### Profiles
 
@@ -423,6 +429,7 @@ The following resources are currently available:
   * `ephemeral` - *Optional* - Boolean indicating if this container is ephemeral. Default = false.
   * `privileged`- *Optional* - Boolean indicating if this container will run in privileged mode. Default = false.
   * `config`    - *Optional* - Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
+  * `limits`    - *Optional* - Map of key/value pairs that define the [container resources limits](https://github.com/lxc/lxd/blob/master/doc/containers.md).
   * `device`    - *Optional* - Device definition. See reference below.
   * `file`      - *Optional* - File to upload to the container. See reference below.
   * `remote`    - *Optional* - The remote in which the resource will be created. If it

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -192,7 +192,7 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 		image = imgParts[1]
 	}
 	config := resourceLxdConfigMap(d.Get("config"))
-	config = resourceLxdConfigMapAppend(d.Get("limits"), config, "limits.")
+	config = resourceLxdConfigMapAppend(config, d.Get("limits"), "limits.")
 
 	devices := resourceLxdDevices(d.Get("device"))
 

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -299,6 +299,32 @@ func TestAccContainer_defaultProfile(t *testing.T) {
 	})
 }
 
+func TestAccContainer_configLimits(t *testing.T) {
+	var container api.Container
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainer_configLimits_1(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_container.container1", "limits.cpu", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccContainer_configLimits_2(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_container.container1", "limits.cpu", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccContainerRunning(t *testing.T, n string, container *api.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -454,7 +480,7 @@ func testAccContainer_basic(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -464,7 +490,7 @@ func testAccContainer_config(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
   config {
     limits.cpu = 2
@@ -533,7 +559,7 @@ func testAccContainer_device_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   device {
@@ -552,7 +578,7 @@ func testAccContainer_device_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   device {
@@ -571,7 +597,7 @@ func testAccContainer_addDevice_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -581,7 +607,7 @@ func testAccContainer_addDevice_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   device {
@@ -600,7 +626,7 @@ func testAccContainer_removeDevice_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   device {
@@ -619,7 +645,7 @@ func testAccContainer_removeDevice_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -629,7 +655,7 @@ func testAccContainer_fileUpload_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   file {
@@ -646,7 +672,7 @@ func testAccContainer_fileUpload_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   file {
@@ -674,6 +700,34 @@ func testAccContainer_defaultProfile(name string) string {
 resource "lxd_container" "container1" {
   name = "%s"
   image = "ubuntu"
+}
+	`, name)
+}
+
+func testAccContainer_configLimits_1(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.5/amd64"
+  profiles = ["default"]
+
+  limits {
+	  "cpu" = "1"
+  }
+}
+	`, name)
+}
+
+func testAccContainer_configLimits_2(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.5/amd64"
+  profiles = ["default"]
+
+  limits {
+	  "cpu" = "2"
+  }
 }
 	`, name)
 }

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -64,19 +64,24 @@ func resourceLxdConfigMap(c interface{}) map[string]string {
 	return config
 }
 
-func resourceLxdConfigMapAppend(c interface{}, config map[string]string, namespace string) map[string]string {
+// resourceLxdConfigMapAppend appends a map of configuration values
+// to an existing map. All appended config values are prefixed
+// with the config namespace.
+func resourceLxdConfigMapAppend(config map[string]string, append interface{}, namespace string) map[string]string {
 	if config == nil {
-		config = make(map[string]string)
+		panic("config is nil")
 	}
 
 	if string(namespace[len(namespace)-1]) != "." {
 		namespace += "."
 	}
 
-	if v, ok := c.(map[string]interface{}); ok {
+	if v, ok := append.(map[string]interface{}); ok {
 		for key, val := range v {
 			config[namespace+key] = val.(string)
 		}
+	} else {
+		panic("append map is not of type map[string]string")
 	}
 
 	log.Printf("[DEBUG] LXD Configuration Map: %#v", config)

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -64,6 +64,26 @@ func resourceLxdConfigMap(c interface{}) map[string]string {
 	return config
 }
 
+func resourceLxdConfigMapAppend(c interface{}, config map[string]string, namespace string) map[string]string {
+	if config == nil {
+		config = make(map[string]string)
+	}
+
+	if string(namespace[len(namespace)-1]) != "." {
+		namespace += "."
+	}
+
+	if v, ok := c.(map[string]interface{}); ok {
+		for key, val := range v {
+			config[namespace+key] = val.(string)
+		}
+	}
+
+	log.Printf("[DEBUG] LXD Configuration Map: %#v", config)
+
+	return config
+}
+
 func resourceLxdDevices(d interface{}) map[string]map[string]string {
 	devices := make(map[string]map[string]string)
 	for _, v := range d.([]interface{}) {


### PR DESCRIPTION
This allows updating the resource limits of a container. 
This PR replace #51 

A new container resource attribute `limits` is added, that behaves similar to the `config` attribute, but allows value changes to be updated without a container destroy + recreate cycle.

**Example config:**
```hcl
resource "lxd_container" "c1" {
  name = "c1"
  image = "ubuntu"

  limits {
    "cpu" = "2"
  }
}
```
