### PR TITLE
Use Partial for Container Creation

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -171,6 +171,9 @@ func resourceLxdContainer() *schema.Resource {
 func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error {
 	var err error
 
+	// Using Partial to resume uploading files if there was a previous error.
+	d.Partial(true)
+
 	p := meta.(*LxdProvider)
 	remote := p.selectRemote(d)
 	server, err := p.GetContainerServer(remote)
@@ -257,6 +260,16 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 	// Container has been created, store ID
 	d.SetId(name)
 
+	d.SetPartial("name")
+	d.SetPartial("image")
+	d.SetPartial("profiles")
+	d.SetPartial("ephemeral")
+	d.SetPartial("privileged")
+	d.SetPartial("config")
+	d.SetPartial("limits")
+	d.SetPartial("device")
+	d.SetPartial("remote")
+
 	// Upload any files, if specified,
 	// and set the contents to a hash in the State
 	if files, ok := d.GetOk("file"); ok {
@@ -271,6 +284,9 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 
 		d.Set("file", files)
 	}
+
+	d.SetPartial("file")
+	d.Partial(false)
 
 	// Start container
 	startReq := api.ContainerStatePut{


### PR DESCRIPTION
This commit uses "partial" for container creation. This should enable
containers to resume uploading files if there was previously an error
during creation, without having to do a full recreate of the container.

For #66 