### PR TITLE
Don't set config on storage pools

### DIFF
--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -95,8 +95,6 @@ func resourceLxdStoragePoolRead(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Retrieved storage pool %s: %#v", name, pool)
 
-	d.Set("config", pool.Config)
-
 	return nil
 }
 


### PR DESCRIPTION
This commit stops config information from being set in the state for
storage pools. This is because most storage pool config items cannot
be altered once the storage pool is created. Since the LXD API
sometimes returns different config values or omits config values,
Terraform will want to send the information back to LXD, which triggers
LXD errors.

For #75 