### PR TITLE
Add profile import

### DIFF
--- a/lxd/import_resource_lxd_profile_test.go
+++ b/lxd/import_resource_lxd_profile_test.go
@@ -27,9 +27,3 @@ func TestLXDProfile_importBasic(t *testing.T) {
 		},
 	})
 }
-
-const testLXDProfileDefault = `
-resource "lxd_profile" "default" {
-	name = "default"
-}
-`

--- a/lxd/import_resource_lxd_profile_test.go
+++ b/lxd/import_resource_lxd_profile_test.go
@@ -1,0 +1,35 @@
+package lxd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestLXDProfile_importBasic(t *testing.T) {
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	resourceName := "lxd_profile.profile1"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_basic(profileName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+const testLXDProfileDefault = `
+resource "lxd_profile" "default" {
+	name = "default"
+}
+`

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -2,6 +2,7 @@ package lxd
 
 import (
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -223,19 +224,26 @@ func resourceLxdProfileExists(d *schema.ResourceData, meta interface{}) (exists 
 
 func resourceLxdProfileImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	p := meta.(*LxdProvider)
+
+	ids := strings.SplitN(d.Id(), ":", 2)
+	name := ids[0]
+	d.SetId(name)
+
+	if len(ids) == 2 {
+		d.Set("remote", ids[1])
+	}
+
 	server, err := p.GetContainerServer(p.selectRemote(d))
 	if err != nil {
 		return nil, err
 	}
-
-	name := d.Id()
 
 	profile, _, err := server.GetProfile(name)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Printf("[DEBUG] Retrieved profile %s: %#v", name, profile)
+	log.Printf("[DEBUG] Import Retrieved profile %s: %#v", name, profile)
 
 	d.Set("name", name)
 	return []*schema.ResourceData{d}, nil

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -114,8 +114,17 @@ func resourceLxdProfileRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("description", profile.Description)
 	d.Set("config", profile.Config)
-	d.Set("device", profile.Devices)
 
+	devices := make([]map[string]interface{}, 0)
+	for name, lxddevice := range profile.Devices {
+		device := make(map[string]interface{})
+		device["name"] = name
+		device["type"] = lxddevice["type"]
+		delete(lxddevice, "type")
+		device["properties"] = lxddevice
+		devices = append(devices, device)
+	}
+	d.Set("device", devices)
 	return nil
 }
 

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -2,7 +2,6 @@ package lxd
 
 import (
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 
@@ -230,13 +229,15 @@ func resourceLxdProfileExists(d *schema.ResourceData, meta interface{}) (exists 
 
 func resourceLxdProfileImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	p := meta.(*LxdProvider)
+	remote, name, err := p.Config.ParseRemote(d.Id())
 
-	ids := strings.SplitN(d.Id(), ":", 2)
-	name := ids[0]
+	if err != nil {
+		return nil, err
+	}
+
 	d.SetId(name)
-
-	if len(ids) == 2 {
-		d.Set("remote", ids[1])
+	if p.Config.DefaultRemote != remote {
+		d.Set("remote", remote)
 	}
 
 	server, err := p.GetContainerServer(p.selectRemote(d))

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -158,6 +158,12 @@ func resourceLxdProfileUpdate(d *schema.ResourceData, meta interface{}) error {
 		newProfile.Description = newDescription.(string)
 	}
 
+	if d.HasChange("config") {
+		changed = true
+		_, newConfig := d.GetChange("config")
+		newProfile.Config = resourceLxdConfigMap(newConfig)
+	}
+
 	if d.HasChange("device") {
 		changed = true
 		old, new := d.GetChange("device")


### PR DESCRIPTION
This adds the option to import lxd_profiles.
it also fixes a bug in the resourceLxdProfileRead function, which didn't read the devices from lxd because of a error in the data formating.

I could use some help with creating test cases for this, that is why i marked it with WIP