### PR TITLE
Container Access Interface

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -342,8 +342,8 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+	log.Printf("[DEBUG] Retrieved container state %s:\n%#v", name, state)
 
-	log.Printf("[DEBUG] Retrieved container config %s:\n%#v", name, container.Config)
 	for k, v := range container.Config {
 		if strings.Contains(k, "limits.") {
 			log.Printf("[DEBUG] Setting limit %s: %s", k, v)

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -354,13 +354,33 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", container.Status)
 
 	sshIP := ""
-	for iface, net := range state.Network {
-		if iface != "lo" {
-			for _, ip := range net.Addresses {
-				if ip.Family == "inet" {
-					d.Set("ip_address", ip.Address)
-					sshIP = ip.Address
-					d.Set("mac_address", net.Hwaddr)
+	// First see if there was an access_interface set.
+	// If there was, base ip_address and mac_address off of it.
+	var aiFound bool
+	if ai, ok := container.Config["user.access_interface"]; ok {
+		net := state.Network[ai]
+		log.Printf("[DEBUG] FOO: %#v", net)
+		for _, ip := range net.Addresses {
+			if ip.Family == "inet" {
+				aiFound = true
+				d.Set("ip_address", ip.Address)
+				sshIP = ip.Address
+				d.Set("mac_address", net.Hwaddr)
+			}
+		}
+	}
+
+	// If the above wasn't successful, try to automatically
+	// determine the ip_address and mac_address.
+	if !aiFound {
+		for iface, net := range state.Network {
+			if iface != "lo" {
+				for _, ip := range net.Addresses {
+					if ip.Family == "inet" {
+						d.Set("ip_address", ip.Address)
+						sshIP = ip.Address
+						d.Set("mac_address", net.Hwaddr)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This commit enables a user to specify which interface will
be used for the ip_address and mac_address in a container
by specifying a user.access_interface config setting.

I opted to use a config setting rather than a first-class Terraform parameter since `user.access_interface` should be able to be set in a profile and then be applied to all containers using that profile.

For #93 