### PR TITLE
Fix profile importing with older versions of LXD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sudo apt-get install -y snapd
   - sudo snap install lxd
   - export PATH=/snap/bin/:${PATH}
-  - sleep 10 # give lxd time to start
+  - sudo lxd waitready --timeout 60
   - sudo lxd init --auto --trust-password="${LXD_PASSWORD}" --network-port=8443 --network-address='[::]'
   - sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
   - 'lxc image copy ubuntu:t local: --alias=ubuntu'

--- a/lxd/import_resource_lxd_profile_test.go
+++ b/lxd/import_resource_lxd_profile_test.go
@@ -27,3 +27,43 @@ func TestLXDProfile_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestLXDProfile_importConfig(t *testing.T) {
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	resourceName := "lxd_profile.profile1"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_config(profileName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestLXDProfile_importDevice(t *testing.T) {
+	profileName := strings.ToLower(petname.Generate(2, "-"))
+	resourceName := "lxd_profile.profile1"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccProfile_device_1(profileName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -529,7 +529,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default"]
 }
 	`, profileName, containerName)
@@ -543,7 +543,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -557,7 +557,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -571,7 +571,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default"]
 }
 	`, profileName, containerName)
@@ -721,7 +721,7 @@ func testAccContainer_defaultProfile(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
 }
 	`, name)
 }

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -155,7 +155,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 `, profileName, containerName)

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -119,6 +119,7 @@ func resourceLxdProfileRead(d *schema.ResourceData, meta interface{}) error {
 	for name, lxddevice := range profile.Devices {
 		device := make(map[string]interface{})
 		device["name"] = name
+		delete(lxddevice, "name")
 		device["type"] = lxddevice["type"]
 		delete(lxddevice, "type")
 		device["properties"] = lxddevice

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -418,7 +418,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -440,7 +440,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -97,7 +97,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default"]
 }
 
@@ -127,7 +127,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "ubuntu"
+  image = "images:alpine/3.5"
   profiles = ["default"]
 }
 


### PR DESCRIPTION
On Ubuntu xenial with lxd version 2.0.9 importing a profile resulted in de following device 
```
  device.# = 1
  device.0.name = eth0
  device.0.properties.% = 3
  device.0.properties.name = eth0
  device.0.properties.nictype = bridged
  device.0.properties.parent = br2
  device.0.type = nic
```

where  **device.0.properties.name** is obvious 'wrong' 

added 2 testcases, one for config and one for devices.
on recent lxd releases, like i'm running on my laptop, this isn't an issue but it is in my production environment.

