### PR TITLE
add import for storage pools wth basic import test

### DIFF
--- a/lxd/import_resource_lxd_storage_pool_test.go
+++ b/lxd/import_resource_lxd_storage_pool_test.go
@@ -1,0 +1,29 @@
+package lxd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccLxdStoragePool_importBasic(t *testing.T) {
+	poolName := strings.ToLower(petname.Generate(2, "-"))
+	resourceName := "lxd_storage_pool.storage_pool1"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccStoragePool_basic(poolName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/lxc/lxd/shared/api"
@@ -15,6 +16,9 @@ func resourceLxdStoragePool() *schema.Resource {
 		Delete: resourceLxdStoragePoolDelete,
 		Exists: resourceLxdStoragePoolExists,
 		Read:   resourceLxdStoragePoolRead,
+		Importer: &schema.ResourceImporter{
+			State: resourceLxdStoragePoolImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -92,6 +96,15 @@ func resourceLxdStoragePoolRead(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
+	d.Set("driver", pool.Driver)
+	config := pool.Config
+	delete(config, "name")
+	for k, _ := range config {
+		if strings.HasPrefix(k, "volatile") {
+			delete(config, k)
+		}
+	}
+	d.Set("config", config)
 
 	log.Printf("[DEBUG] Retrieved storage pool %s: %#v", name, pool)
 
@@ -160,4 +173,33 @@ func resourceLxdStoragePoolExists(d *schema.ResourceData, meta interface{}) (exi
 	}
 
 	return
+}
+
+func resourceLxdStoragePoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	p := meta.(*LxdProvider)
+	remote, name, err := p.Config.ParseRemote(d.Id())
+	log.Printf("[DEBUG] Import storage pool from remote: %s name: %s", remote, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(name)
+	if p.Config.DefaultRemote != remote {
+		d.Set("remote", remote)
+	}
+
+	server, err := p.GetContainerServer(p.selectRemote(d))
+	if err != nil {
+		return nil, err
+	}
+
+	pool, _, err := server.GetStoragePool(name)
+	log.Printf("[DEBUG] Import Retrieved storage pool %s: %#v", name, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("name", name)
+	return []*schema.ResourceData{d}, nil
 }

--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -178,11 +178,11 @@ func resourceLxdStoragePoolExists(d *schema.ResourceData, meta interface{}) (exi
 func resourceLxdStoragePoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	p := meta.(*LxdProvider)
 	remote, name, err := p.Config.ParseRemote(d.Id())
-	log.Printf("[DEBUG] Import storage pool from remote: %s name: %s", remote, name)
 
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("[DEBUG] Import storage pool from remote: %s name: %s", remote, name)
 
 	d.SetId(name)
 	if p.Config.DefaultRemote != remote {
@@ -195,10 +195,10 @@ func resourceLxdStoragePoolImport(d *schema.ResourceData, meta interface{}) ([]*
 	}
 
 	pool, _, err := server.GetStoragePool(name)
-	log.Printf("[DEBUG] Import Retrieved storage pool %s: %#v", name, pool)
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("[DEBUG] Import Retrieved storage pool %s: %#v", name, pool)
 
 	d.Set("name", name)
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
add import support for storage pools

add the following to the resource config
```hcl
resource "lxd_storage_pool" "default" {
  name = "default"
  config {
    source = "/var/lib/lxd/storage-pools/default"
  }
  driver = "dir"

}
```

and run the command
`terraform import lxd_storage_pool.default default`

PS: i created for the storage pool test issues the issue lxc/lxd#3877, because i can reproduce them with lxc cli command