### PR TITLE
Add description field to network resource

### DIFF
--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -3,7 +3,6 @@ package lxd
 import (
 	"log"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -192,10 +191,7 @@ func TestAccLxdProvider_noConfigFile(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	cmd := exec.Command("lxc", "--version")
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("LXD client must be available: %s", err)
-	}
+	// NoOp
 }
 
 func testAccLxdProvider_basic(remote string) string {

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -22,6 +22,12 @@ func resourceLxdNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"config": &schema.Schema{
 				Type:     schema.TypeMap,
 				Required: true,
@@ -56,11 +62,13 @@ func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	name := d.Get("name").(string)
+	desc := d.Get("description").(string)
 	config := resourceLxdConfigMap(d.Get("config"))
 
 	log.Printf("[DEBUG] Creating network %s with config: %#v", name, config)
 	req := api.NetworksPost{Name: name}
 	req.Config = config
+	req.Description = desc
 	if err := server.CreateNetwork(req); err != nil {
 		if err.Error() == "not implemented" {
 			err = ErrNetworksNotImplemented
@@ -90,6 +98,7 @@ func resourceLxdNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Retrieved network %s: %#v", name, network)
 
 	d.Set("config", network.Config)
+	d.Set("description", network.Description)
 	d.Set("type", network.Type)
 	d.Set("managed", network.Managed)
 

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dustinkirkland/golang-petname"
-
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
@@ -26,6 +25,24 @@ func TestAccNetwork_basic(t *testing.T) {
 					testAccNetworkExists(t, "lxd_network.eth1", &network),
 					testAccNetworkConfig(&network, "ipv4.address", "10.150.19.1/24"),
 					resource.TestCheckResourceAttr("lxd_network.eth1", "name", "eth1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetwork_description(t *testing.T) {
+	var network api.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetwork_desc(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetworkExists(t, "lxd_network.eth1", &network),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "description", "descriptive"),
 				),
 			},
 		},
@@ -116,6 +133,22 @@ func testAccNetwork_basic() string {
 	return fmt.Sprintf(`
 resource "lxd_network" "eth1" {
   name = "eth1"
+
+  config {
+    ipv4.address = "10.150.19.1/24"
+    ipv4.nat = "true"
+    ipv6.address = "fd42:474b:622d:259d::1/64"
+    ipv6.nat = "true"
+  }
+}
+`)
+}
+
+func testAccNetwork_desc() string {
+	return fmt.Sprintf(`
+resource "lxd_network" "eth1" {
+	name        = "eth1"
+	description = "descriptive"
 
   config {
     ipv4.address = "10.150.19.1/24"


### PR DESCRIPTION
Also removed Provider AccTest preCheck. It's no longer requried to run the tests on a system that has the lxc provider installed.

Fixes #106