### PR TITLE
Container fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,8 @@ The following resources are currently available:
                                is not provided, the default provider remote is used.
 
 ##### Importing
-Importing existing containers is possible with the following ID syntax  
-`terraform import lxd_container.container [remote:]name[/images:alpine/3.5]`.  
+Importing existing containers is possible with the following ID syntax
+`terraform import lxd_container.container [remote:]name[/images:alpine/3.5]`.
 
  * remote             - *Optional* - is the name of the remote in the provider config
  * name               - *Required* - is the container name
@@ -495,7 +495,8 @@ resource "lxd_container" "container1" {
 
 ##### File Block
 
-  * `content` - *Required* - The _contents_ of the file. Use the `file()` function to read in the content of a file from disk.
+  * `content` - *Required unless source is used* - The _contents_ of the file. Use the `file()` function to read in the content of a file from disk.
+  * `source` - *Required unless content is used* - The path to the source file to copy to the container.
   * `target_file` - *Required* - The absolute path of the file on the container, including the filename.
   * `uid` - *Optional* - The UID of the file. Must be an unquoted integer.
   * `gid` - *Optional* - The GID of the file. Must be an unquoted integer.

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ The following resources are currently available:
   * `image`     - *Required* - Base image from which the container will be created.
   * `profiles`  - *Optional* - Array of LXD config profiles to apply to the new container.
   * `ephemeral` - *Optional* - Boolean indicating if this container is ephemeral. Default = false.
-  * `privileged`- *Optional* - Boolean indicating if this container will run in privileged mode. Default = false.
+  * `privileged`- *Deprecated* - Boolean indicating if this container will run in privileged mode. Default = false. This argument is deprecated. Use a config setting of `security.privileged=1` instead.
   * `config`    - *Optional* - Map of key/value pairs of [container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
   * `limits`    - *Optional* - Map of key/value pairs that define the [container resources limits](https://github.com/lxc/lxd/blob/master/doc/containers.md).
   * `device`    - *Optional* - Device definition. See reference below.

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -105,10 +105,11 @@ func resourceLxdContainer() *schema.Resource {
 			},
 
 			"privileged": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: false,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Default:    false,
+				ForceNew:   false,
+				Deprecated: "Use a config setting of security.privileged=1 instead",
 			},
 
 			"file": &schema.Schema{

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -1,8 +1,6 @@
 package lxd
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"os"
@@ -14,6 +12,8 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+
+	"github.com/mitchellh/go-homedir"
 
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/shared/api"
@@ -119,11 +119,12 @@ func resourceLxdContainer() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"content": &schema.Schema{
 							Type:     schema.TypeString,
-							Required: true,
-							StateFunc: func(v interface{}) string {
-								hash := sha1.Sum([]byte(v.(string)))
-								return hex.EncodeToString(hash[:])
-							},
+							Optional: true,
+						},
+
+						"source": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 
 						"target_file": &schema.Schema{
@@ -283,8 +284,6 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 			if err := resourceLxdContainerUploadFile(server, name, file); err != nil {
 				return err
 			}
-			hash := sha1.Sum([]byte(file["content"].(string)))
-			file["content"] = hex.EncodeToString(hash[:])
 		}
 
 		d.Set("file", files)
@@ -654,28 +653,42 @@ func resourceLxdContainerRefresh(server lxd.ContainerServer, name string) resour
 }
 
 func resourceLxdContainerUploadFile(server lxd.ContainerServer, container string, file interface{}) error {
-	var uid, gid int
-	var createDirectories bool
 	fileInfo := file.(map[string]interface{})
 
-	fileContent := fileInfo["content"].(string)
-	fileTarget := fileInfo["target_file"].(string)
+	var fileContent string
+	if v, ok := fileInfo["content"]; ok {
+		fileContent = v.(string)
+	}
 
+	var fileSource string
+	if v, ok := fileInfo["source"]; ok {
+		fileSource = v.(string)
+	}
+
+	// Both content and source cannot be set.
+	if fileContent != "" && fileSource != "" {
+		return fmt.Errorf("only one of content or source can be used in a file")
+	}
+
+	var uid int
 	if v, ok := fileInfo["uid"]; ok {
 		uid = v.(int)
 	}
 
+	var gid int
 	if v, ok := fileInfo["gid"]; ok {
 		gid = v.(int)
 	}
 
+	var createDirectories bool
 	if v, ok := fileInfo["create_directories"]; ok {
 		createDirectories = v.(bool)
 	}
 
+	fileTarget := fileInfo["target_file"].(string)
 	fileTarget, err := filepath.Abs(fileTarget)
 	if err != nil {
-		return fmt.Errorf("Could not santize destination target %s", fileTarget)
+		return fmt.Errorf("Could not determine destination target %s", fileTarget)
 	}
 
 	targetIsDir := strings.HasSuffix(fileTarget, "/")
@@ -697,6 +710,36 @@ func resourceLxdContainerUploadFile(server lxd.ContainerServer, container string
 		mode = os.FileMode(m)
 	}
 
+	// Build the file creation request, without the content.
+	args := lxd.ContainerFileArgs{
+		Mode:      int(mode.Perm()),
+		UID:       int64(uid),
+		GID:       int64(gid),
+		Type:      "file",
+		WriteMode: "overwrite",
+	}
+
+	// If content was specified, read the string.
+	if fileContent != "" {
+		args.Content = strings.NewReader(fileContent)
+	}
+
+	// If a source was specified, read the contents of the source file.
+	if fileSource != "" {
+		path, err := homedir.Expand(fileSource)
+		if err != nil {
+			return fmt.Errorf("unable to determine source file path: %s", err)
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("unable to read source file: %s", err)
+		}
+		defer f.Close()
+
+		args.Content = f
+	}
+
 	log.Printf("[DEBUG] Attempting to upload file to %s with uid %d, gid %d, and mode %s",
 		fileTarget, uid, gid, fmt.Sprintf("%04o", mode))
 
@@ -707,15 +750,6 @@ func resourceLxdContainerUploadFile(server lxd.ContainerServer, container string
 		}
 	}
 
-	f := strings.NewReader(fileContent)
-	args := lxd.ContainerFileArgs{
-		Mode:      int(mode.Perm()),
-		UID:       int64(uid),
-		GID:       int64(gid),
-		Type:      "file",
-		Content:   f,
-		WriteMode: "overwrite",
-	}
 	if err := server.CreateContainerFile(container, fileTarget, args); err != nil {
 		return fmt.Errorf("Could not upload file %s: %s", fileTarget, err)
 	}

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -255,7 +255,7 @@ func TestAccContainer_removeDevice(t *testing.T) {
 	})
 }
 
-func TestAccContainer_fileUpload(t *testing.T) {
+func TestAccContainer_fileUploadContent(t *testing.T) {
 	var container api.Container
 	containerName := strings.ToLower(petname.Generate(2, "-"))
 
@@ -264,13 +264,31 @@ func TestAccContainer_fileUpload(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccContainer_fileUpload_1(containerName),
+				Config: testAccContainer_fileUploadContent_1(containerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 				),
 			},
 			resource.TestStep{
-				Config: testAccContainer_fileUpload_2(containerName),
+				Config: testAccContainer_fileUploadContent_2(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+				),
+			},
+		},
+	})
+}
+
+func TestAccContainer_fileUploadSource(t *testing.T) {
+	var container api.Container
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainer_fileUploadSource(containerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 				),
@@ -673,7 +691,7 @@ resource "lxd_container" "container1" {
 	`, name)
 }
 
-func testAccContainer_fileUpload_1(name string) string {
+func testAccContainer_fileUploadContent_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
@@ -690,7 +708,7 @@ resource "lxd_container" "container1" {
 	`, name)
 }
 
-func testAccContainer_fileUpload_2(name string) string {
+func testAccContainer_fileUploadContent_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
@@ -699,6 +717,23 @@ resource "lxd_container" "container1" {
 
   file {
     content = "Goodbye, World!\n"
+    target_file = "/foo/bar.txt"
+    mode = "0644"
+    create_directories = true
+  }
+}
+	`, name)
+}
+
+func testAccContainer_fileUploadSource(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.5/amd64"
+  profiles = ["default"]
+
+  file {
+    source = "test-fixtures/test-file.txt"
     target_file = "/foo/bar.txt"
     mode = "0644"
     create_directories = true

--- a/lxd/test-fixtures/test-file.txt
+++ b/lxd/test-fixtures/test-file.txt
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
This PR contains two fixes for the `lxd_container` resource:

1. Deprecates the `privileged` parameter (fixes #102)
2. Adds the ability to specify a `source` for the `file` argument (fixes #53 and #82)

The implementation of 2 (notably the use of `homedir.Expand`) is based on the AWS S3 object resource.

2 is a breaking change. It will no longer store the checksum of the file contents in the state.

Additionally, there is no easy way to check and see if the content of the source file has changed. This means if someone updates the contents of the source file and runs `terraform apply`, the changes will not be noticed.

In my opinion, this is an acceptable limitation. Full management of files within the `lxd_container` resource is difficult. It would be much better to have a dedicated `lxd_container_file` resource (which I plan on creating shortly). I thought about completely removing the `lxd_container.file` argument entirely, but being able to add files _before_ the container starts has benefits. 

So I think the best practice should be:

* Use `lxd_container.file` for bootstrapping / prepping containers
* Use `lxd_container_file` for management of files in a running container

Once the `lxd_container_file` resource is made, I will detail this in the docs.