### PR TITLE
Container file resource

### DIFF
--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -7,6 +7,7 @@
 ### Container
 
 * [`lxd_container`](lxd_container.md)
+* [`lxd_container_file`](lxd_container_file.md)
 * [`lxd_snapshot`](lxd_snapshot.md)
 
 ### Network

--- a/docs/resources/lxd_container_file.md
+++ b/docs/resources/lxd_container_file.md
@@ -1,0 +1,50 @@
+# lxd_container_file
+
+Manages a file in an LXD container.
+
+This resource is useful for managing files on an existing LXD container.
+If you need to preload files in a container before the container first
+starts, use the `file` block in the `lxd_container` resource.
+
+## Example
+
+```hcl
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "ubuntu"
+  ephemeral = false
+}
+
+resource "lxd_container_file" "file1" {
+  container_name     = "${lxd_container.test1.name}"
+  target_file        = "/foo/bar.txt"
+  source             = "/path/to/local/file"
+  create_directories = true
+```
+
+## Argument Reference
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+	it is not provided, the default provider remote is used.
+
+* `container_name` - *Required* - Name of the container.
+
+* `content` - *Required unless source is used* - The _contents_ of the file.
+	Use the `file()` function to read in the content of a file from disk.
+
+* `source` - *Required unless content is used* The source path to a file to
+	copy to the container.
+
+* `target_file` - *Required* - The absolute path of the file on the container,
+	including the filename.
+
+* `uid` - *Optional* - The UID of the file. Must be an unquoted integer.
+  Defaults to `0`.
+
+* `gid` - *Optional* - The GID of the file. Must be an unquoted integer.
+  Defaults to `0`.
+
+* `mode` - *Optional* - The octal permissions of the file, must be quoted.
+
+* `create_directories` - *Optional* - Whether to create the directories leading
+	to the target if they do not exist.

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -149,6 +149,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"lxd_cached_image":            resourceLxdCachedImage(),
 			"lxd_container":               resourceLxdContainer(),
+			"lxd_container_file":          resourceLxdContainerFile(),
 			"lxd_network":                 resourceLxdNetwork(),
 			"lxd_profile":                 resourceLxdProfile(),
 			"lxd_snapshot":                resourceLxdSnapshot(),

--- a/lxd/resource_lxd_container_file.go
+++ b/lxd/resource_lxd_container_file.go
@@ -1,0 +1,194 @@
+package lxd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceLxdContainerFile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLxdContainerFileCreate,
+		Exists: resourceLxdContainerFileExists,
+		Read:   resourceLxdContainerFileRead,
+		Delete: resourceLxdContainerFileDelete,
+
+		Schema: map[string]*schema.Schema{
+			"container_name": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"target_file": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"content": &schema.Schema{
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"source"},
+			},
+
+			"source": &schema.Schema{
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"content"},
+			},
+
+			"uid": &schema.Schema{
+				Type:     schema.TypeInt,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"gid": &schema.Schema{
+				Type:     schema.TypeInt,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"mode": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"create_directories": &schema.Schema{
+				Type:     schema.TypeBool,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			"remote": &schema.Schema{
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceLxdContainerFileCreate(d *schema.ResourceData, meta interface{}) error {
+	p := meta.(*lxdProvider)
+	remote := p.selectRemote(d)
+	server, err := p.GetContainerServer(remote)
+	if err != nil {
+		return err
+	}
+
+	containerName := d.Get("container_name").(string)
+	_, _, err = server.GetContainer(containerName)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve container %s: %s", containerName, err)
+	}
+
+	file := File{
+		RemoteName:        remote,
+		ContainerName:     containerName,
+		TargetFile:        d.Get("target_file").(string),
+		Content:           d.Get("content").(string),
+		Source:            d.Get("source").(string),
+		UID:               d.Get("uid").(int),
+		GID:               d.Get("gid").(int),
+		Mode:              d.Get("mode").(string),
+		CreateDirectories: d.Get("create_directories").(bool),
+	}
+
+	err = containerUploadFile(server, containerName, file)
+	if err != nil {
+		return fmt.Errorf("unable to create file %s: %s", file.TargetFile, err)
+	}
+
+	d.SetId(file.String())
+	return nil
+}
+
+func resourceLxdContainerFileRead(d *schema.ResourceData, meta interface{}) error {
+	p := meta.(*lxdProvider)
+	v, targetFile := newFileIDFromResourceID(d.Id())
+	remote, containerName, err := p.Config.ParseRemote(v)
+
+	remote = p.selectRemote(d)
+	server, err := p.GetContainerServer(remote)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = server.GetContainer(containerName)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve container %s: %s", containerName, err)
+	}
+
+	_, file, err := server.GetContainerFile(containerName, targetFile)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve file %s:%s: %s", containerName, targetFile, err)
+	}
+
+	log.Printf("[DEBUG] Retrieved file: %#v", file)
+
+	d.Set("container_name", containerName)
+	d.Set("target_file", targetFile)
+	d.Set("uid", file.UID)
+	d.Set("gid", file.GID)
+	d.Set("mode", file.Mode)
+
+	return nil
+}
+
+func resourceLxdContainerFileDelete(d *schema.ResourceData, meta interface{}) error {
+	p := meta.(*lxdProvider)
+	v, targetFile := newFileIDFromResourceID(d.Id())
+	remote, containerName, err := p.Config.ParseRemote(v)
+	server, err := p.GetContainerServer(remote)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = server.GetContainer(containerName)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve container %s: %s", containerName, err)
+	}
+
+	err = containerDeleteFile(server, containerName, targetFile)
+	if err != nil {
+		return fmt.Errorf("unable to delete file %s:%s: %s", containerName, targetFile, err)
+	}
+
+	return nil
+}
+
+func resourceLxdContainerFileExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
+	p := meta.(*lxdProvider)
+	v, targetFile := newFileIDFromResourceID(d.Id())
+	remote, containerName, err := p.Config.ParseRemote(v)
+	if err != nil {
+		err = fmt.Errorf("unable to determine remote: %s", err)
+		return
+	}
+
+	server, err := p.GetContainerServer(remote)
+	if err != nil {
+		return
+	}
+
+	_, _, err = server.GetContainer(containerName)
+	if err != nil {
+		err = fmt.Errorf("unable to retrieve container %s: %s", containerName, err)
+		return
+	}
+
+	_, _, err = server.GetContainerFile(containerName, targetFile)
+	if err != nil {
+		return
+	}
+
+	exists = true
+
+	return
+}

--- a/lxd/resource_lxd_container_file_test.go
+++ b/lxd/resource_lxd_container_file_test.go
@@ -1,0 +1,122 @@
+package lxd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/lxc/lxd/client"
+)
+
+func TestAccContainerFile_content(t *testing.T) {
+	var file lxd.ContainerFileResponse
+
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerFile_content(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerFileExists(t, "lxd_container_file.file1", &file),
+					resource.TestCheckResourceAttr("lxd_container_file.file1", "create_directories", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccContainerFile_source(t *testing.T) {
+	var file lxd.ContainerFileResponse
+
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerFile_source(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerFileExists(t, "lxd_container_file.file1", &file),
+					resource.TestCheckResourceAttr("lxd_container_file.file1", "create_directories", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccContainerFileExists(t *testing.T, n string, file *lxd.ContainerFileResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		p := testAccProvider.Meta().(*lxdProvider)
+		v, targetFile := newFileIDFromResourceID(rs.Primary.ID)
+		remote, containerName, err := p.Config.ParseRemote(v)
+
+		client, err := p.GetContainerServer(remote)
+		if err != nil {
+			return err
+		}
+
+		_, f, err := client.GetContainerFile(containerName, targetFile)
+		if err != nil {
+			return err
+		}
+
+		if f != nil {
+			*file = *f
+			return nil
+		}
+
+		return fmt.Errorf("Container file not found: %s", rs.Primary.ID)
+	}
+}
+
+func testAccContainerFile_content(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.5/amd64"
+  profiles = ["default"]
+}
+
+resource "lxd_container_file" "file1" {
+  container_name = "${lxd_container.container1.name}"
+  target_file = "/foo/bar.txt"
+  content = "Hello, World!\n"
+  create_directories = true
+}
+	`, name)
+}
+
+func testAccContainerFile_source(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.5/amd64"
+  profiles = ["default"]
+}
+
+resource "lxd_container_file" "file1" {
+  container_name = "${lxd_container.container1.name}"
+  target_file = "/foo/bar.txt"
+	source = "test-fixtures/test-file.txt"
+  create_directories = true
+}
+	`, name)
+}

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -239,7 +239,7 @@ func containerUploadFile(server lxd.ContainerServer, container string, file File
 func containerDeleteFile(server lxd.ContainerServer, container string, targetFile string) error {
 	targetFile, err := filepath.Abs(targetFile)
 	if err != nil {
-		return fmt.Errorf("Could not santize destination target %s", targetFile)
+		return fmt.Errorf("Could not sanitize destination target %s", targetFile)
 	}
 
 	targetIsDir := strings.HasSuffix(targetFile, "/")

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -3,7 +3,14 @@ package lxd
 import (
 	"fmt"
 	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
 	"strings"
+
+	lxd "github.com/lxc/lxd/client"
+	"github.com/mitchellh/go-homedir"
 )
 
 // Complex resource ID types
@@ -48,6 +55,27 @@ func newVolumeAttachmentIDFromResourceID(id string) volumeAttachmentID {
 	pieces := strings.SplitN(id, "/", 3)
 	log.Printf("[DEBUG] pieces: %#v", pieces)
 	return volumeAttachmentID{pieces[0], pieces[1], pieces[2]}
+}
+
+type File struct {
+	RemoteName        string
+	ContainerName     string
+	TargetFile        string
+	Content           string
+	Source            string
+	UID               int
+	GID               int
+	Mode              string
+	CreateDirectories bool
+}
+
+func (f File) String() string {
+	return fmt.Sprintf("%s:%s%s", f.RemoteName, f.ContainerName, f.TargetFile)
+}
+
+func newFileIDFromResourceID(id string) (string, string) {
+	pieces := strings.SplitN(id, "/", 2)
+	return pieces[0], fmt.Sprintf("/%s", pieces[1])
 }
 
 // Helper functions
@@ -126,4 +154,156 @@ func resourceLxdValidateDeviceType(v interface{}, k string) (ws []string, errors
 	}
 
 	return
+}
+
+// containerUploadFile will upload a file to a container.
+func containerUploadFile(server lxd.ContainerServer, container string, file File) error {
+	if file.Content != "" && file.Source != "" {
+		return fmt.Errorf("only one of content or source can be specified")
+	}
+
+	targetFile, err := filepath.Abs(file.TargetFile)
+	if err != nil {
+		return fmt.Errorf("Could not determine destination target %s", targetFile)
+	}
+
+	targetIsDir := strings.HasSuffix(targetFile, "/")
+	if targetIsDir {
+		return fmt.Errorf("Target must be an absolute path with filename")
+	}
+
+	mode := os.FileMode(0755)
+	if len(file.Mode) != 3 {
+		file.Mode = "0" + file.Mode
+	}
+
+	m, err := strconv.ParseInt(file.Mode, 0, 0)
+	if err != nil {
+		return fmt.Errorf("Could not determine file mode %s", file.Mode)
+	}
+
+	mode = os.FileMode(m)
+
+	// Build the file creation request, without the content.
+	uid := int64(file.UID)
+	gid := int64(file.GID)
+	args := lxd.ContainerFileArgs{
+		Mode:      int(mode.Perm()),
+		UID:       int64(uid),
+		GID:       int64(gid),
+		Type:      "file",
+		WriteMode: "overwrite",
+	}
+
+	// If content was specified, read the string.
+	if file.Content != "" {
+		args.Content = strings.NewReader(file.Content)
+	}
+
+	// If a source was specified, read the contents of the source file.
+	if file.Source != "" {
+		path, err := homedir.Expand(file.Source)
+		if err != nil {
+			return fmt.Errorf("unable to determine source file path: %s", err)
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("unable to read source file: %s", err)
+		}
+		defer f.Close()
+
+		args.Content = f
+	}
+
+	log.Printf("[DEBUG] Attempting to upload file to %s with uid %d, gid %d, and mode %s",
+		targetFile, uid, gid, fmt.Sprintf("%04o", mode))
+
+	if file.CreateDirectories {
+		err := recursiveMkdir(server, container, path.Dir(targetFile), mode, uid, gid)
+		if err != nil {
+			return fmt.Errorf("Could not upload file %s: %s", targetFile, err)
+		}
+	}
+
+	if err := server.CreateContainerFile(container, targetFile, args); err != nil {
+		return fmt.Errorf("Could not upload file %s: %s", targetFile, err)
+	}
+
+	log.Printf("[DEBUG] Successfully uploaded file %s", targetFile)
+
+	return nil
+}
+
+// containerDeleteFile will delete a file on a container.
+func containerDeleteFile(server lxd.ContainerServer, container string, targetFile string) error {
+	targetFile, err := filepath.Abs(targetFile)
+	if err != nil {
+		return fmt.Errorf("Could not santize destination target %s", targetFile)
+	}
+
+	targetIsDir := strings.HasSuffix(targetFile, "/")
+	if targetIsDir {
+		return fmt.Errorf("Target must be an absolute path with filename")
+	}
+
+	log.Printf("[DEBUG] Attempting to delete file %s", targetFile)
+
+	if err := server.DeleteContainerFile(container, targetFile); err != nil {
+		return fmt.Errorf("Could not delete file %s: %s", targetFile, err)
+	}
+
+	log.Printf("[DEBUG] Successfully deleted file %s", targetFile)
+
+	return nil
+}
+
+// recursiveMkdir was copied almost as-is from github.com/lxc/lxd/lxc/file.go
+func recursiveMkdir(d lxd.ContainerServer, container string, p string, mode os.FileMode, uid int64, gid int64) error {
+	/* special case, every container has a /, we don't need to do anything */
+	if p == "/" {
+		return nil
+	}
+
+	// Remove trailing "/" e.g. /A/B/C/. Otherwise we will end up with an
+	// empty array entry "" which will confuse the Mkdir() loop below.
+	pclean := filepath.Clean(p)
+	parts := strings.Split(pclean, "/")
+	i := len(parts)
+
+	for ; i >= 1; i-- {
+		cur := filepath.Join(parts[:i]...)
+		_, resp, err := d.GetContainerFile(container, cur)
+		if err != nil {
+			continue
+		}
+
+		if resp.Type != "directory" {
+			return fmt.Errorf("%s is not a directory", cur)
+		}
+
+		i++
+		break
+	}
+
+	for ; i <= len(parts); i++ {
+		cur := filepath.Join(parts[:i]...)
+		if cur == "" {
+			continue
+		}
+
+		args := lxd.ContainerFileArgs{
+			UID:  uid,
+			GID:  gid,
+			Mode: int(mode.Perm()),
+			Type: "directory",
+		}
+
+		err := d.CreateContainerFile(container, cur, args)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This commit adds the lxd_container_file resource which can be used
to manage individual files in a container.

This depends on #112 

I can rebase afterwards or all 3 commits can be merged here.

Can also add docs once #114 is added.