### PR TITLE
Lazy Load Remotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ terraform-provider-lxd.iml
 **/*.swp
 settings.json
 **/terraform.tfstate*
+**/*.terraform

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	go test -timeout 20m -v ./lxd
 
 testacc:
-	TF_LOG=debug TF_ACC=1 go test ./lxd -v $(TESTARGS)
+	TF_LOG=debug TF_ACC=1 go test -v $(TESTARGS) -timeout 60m ./lxd
 
 build:
 	go build -v

--- a/test-infra/files/deploy.sh
+++ b/test-infra/files/deploy.sh
@@ -18,6 +18,8 @@ sudo snap install lxd
 _lxc="/snap/bin/lxc"
 _lxd="/snap/bin/lxd"
 sudo $_lxd waitready --timeout 60
+sudo /snap/bin/lxd.migrate -yes
+sudo ln -s /snap/bin/lxc /usr/bin/
 sudo $_lxc config set core.https_address [::]
 sudo $_lxc config set core.trust_password the-password
 #sudo $_lxc storage create default dir source=/mnt


### PR DESCRIPTION
This commit enables lazy loading of LXD remotes.
This is useful for when the LXD remote might not
exist yet during an apply.

This Works For Me, but I'm marking this as WIP until acceptance testing clears -- there might be a few bugs it uncovers.

With this patch in place, I can deploy an OpenStack instance, deploy LXD on it, and then provision a container in the new LXD environment all in one manifest.