### PR TITLE
Container File: Recreate when not found

### DIFF
--- a/lxd/resource_lxd_container_file.go
+++ b/lxd/resource_lxd_container_file.go
@@ -185,6 +185,13 @@ func resourceLxdContainerFileExists(d *schema.ResourceData, meta interface{}) (e
 
 	_, _, err = server.GetContainerFile(containerName, targetFile)
 	if err != nil {
+		// If the file could not be found, then it doesn't exist.
+		// Ignore the error and return with exists set to false.
+		if err.Error() == "not found" {
+			err = nil
+			return
+		}
+
 		return
 	}
 


### PR DESCRIPTION
This commit will cause an lxd_container_file resource to
be recreated when it's not found.