### PR TITLE
Container File: Recreate when container not found

### DIFF
--- a/lxd/resource_lxd_container_file.go
+++ b/lxd/resource_lxd_container_file.go
@@ -179,6 +179,14 @@ func resourceLxdContainerFileExists(d *schema.ResourceData, meta interface{}) (e
 
 	_, _, err = server.GetContainer(containerName)
 	if err != nil {
+		// If the container could not be found, then the file
+		// can't exist. Ignore the error and return with exists
+		// set to false.
+		if err.Error() == "not found" {
+			err = nil
+			return
+		}
+
 		err = fmt.Errorf("unable to retrieve container %s: %s", containerName, err)
 		return
 	}


### PR DESCRIPTION
This commit modifies the behavior of the lxd_container_file
resource so that it is marked as not existing when the
container itself does not exist.

This is useful in situations when the container was deleted
out of band of Terraform.

Similar to #130 but now accounts for when the _container_ doesn't exist.