### PR TITLE
Bugfix: retry resourceLxdContainerRead if "inet" is not found in container status

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -416,7 +416,9 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		if sshIP != "" { break }
+		if sshIP != "" {
+			break
+		}
 		time.Sleep(sleepTime)
 	}
 

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -350,67 +350,72 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	log.Printf("[DEBUG] Retrieved container %s: %#v", name, container)
 
-	state, _, err := server.GetContainerState(name)
-	if err != nil {
-		return err
-	}
-	log.Printf("[DEBUG] Retrieved container state %s:\n%#v", name, state)
-
-	d.Set("ephemeral", container.Ephemeral)
-	d.Set("privileged", false) // Create has no handling for it yet
-
-	config := make(map[string]string)
-	limits := make(map[string]string)
-	for k, v := range container.Config {
-		if strings.Contains(k, "limits.") {
-			limits[strings.TrimPrefix(k, "limits.")] = v
-		} else if strings.HasPrefix(k, "boot.") {
-			config[k] = v
-		} else if strings.HasPrefix(k, "environment.") {
-			config[k] = v
-		} else if strings.HasPrefix(k, "raw.") {
-			config[k] = v
-		} else if strings.HasPrefix(k, "security.") {
-			config[k] = v
-		} else if strings.HasPrefix(k, "user.") {
-			config[k] = v
-		}
-	}
-	d.Set("config", config)
-	d.Set("limits", limits)
-
-	d.Set("status", container.Status)
-
 	sshIP := ""
-	// First see if there was an access_interface set.
-	// If there was, base ip_address and mac_address off of it.
-	var aiFound bool
-	if ai, ok := container.Config["user.access_interface"]; ok {
-		net := state.Network[ai]
-		for _, ip := range net.Addresses {
-			if ip.Family == "inet" {
-				aiFound = true
-				d.Set("ip_address", ip.Address)
-				sshIP = ip.Address
-				d.Set("mac_address", net.Hwaddr)
+	loops := 30
+	sleepTime := 500 * time.Millisecond
+	for i := loops; i > 0 && sshIP == ""; i-- {
+		state, _, err := server.GetContainerState(name)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Retrieved container state %s:\n%#v", name, state)
+
+		d.Set("ephemeral", container.Ephemeral)
+		d.Set("privileged", false) // Create has no handling for it yet
+
+		config := make(map[string]string)
+		limits := make(map[string]string)
+		for k, v := range container.Config {
+			if strings.Contains(k, "limits.") {
+				limits[strings.TrimPrefix(k, "limits.")] = v
+			} else if strings.HasPrefix(k, "boot.") {
+				config[k] = v
+			} else if strings.HasPrefix(k, "environment.") {
+				config[k] = v
+			} else if strings.HasPrefix(k, "raw.") {
+				config[k] = v
+			} else if strings.HasPrefix(k, "security.") {
+				config[k] = v
+			} else if strings.HasPrefix(k, "user.") {
+				config[k] = v
 			}
 		}
-	}
+		d.Set("config", config)
+		d.Set("limits", limits)
 
-	// If the above wasn't successful, try to automatically
-	// determine the ip_address and mac_address.
-	if !aiFound {
-		for iface, net := range state.Network {
-			if iface != "lo" {
-				for _, ip := range net.Addresses {
-					if ip.Family == "inet" {
-						d.Set("ip_address", ip.Address)
-						sshIP = ip.Address
-						d.Set("mac_address", net.Hwaddr)
+		d.Set("status", container.Status)
+
+		// First see if there was an access_interface set.
+		// If there was, base ip_address and mac_address off of it.
+		var aiFound bool
+		if ai, ok := container.Config["user.access_interface"]; ok {
+			net := state.Network[ai]
+			for _, ip := range net.Addresses {
+				if ip.Family == "inet" {
+					aiFound = true
+					d.Set("ip_address", ip.Address)
+					sshIP = ip.Address
+					d.Set("mac_address", net.Hwaddr)
+				}
+			}
+		}
+
+		// If the above wasn't successful, try to automatically
+		// determine the ip_address and mac_address.
+		if !aiFound {
+			for iface, net := range state.Network {
+				if iface != "lo" {
+					for _, ip := range net.Addresses {
+						if ip.Family == "inet" {
+							d.Set("ip_address", ip.Address)
+							sshIP = ip.Address
+							d.Set("mac_address", net.Hwaddr)
+						}
 					}
 				}
 			}
 		}
+		time.Sleep(sleepTime)
 	}
 
 	// Initialize the connection info

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -343,7 +343,7 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	name := d.Id()
-	
+
 	container, _, err := server.GetContainer(name)
 	if err != nil {
 		return err


### PR DESCRIPTION
I have found that when lxd is under heavier than normal load (for example creating 4+ containers at the same time), it takes longer for the network information to propagate into the container state.
This has manifested into the issue where the container status pulled from lxd does not yet have a value for "inet", but the provider will continue to try connecting through ssh with a blank ip_address.

Previously, status was pulled once as soon as the container was "Running", with no "inet" ip_address. But, lxd will transition the container to "Running", and then afterwards add the "inet" ip_address. Thus, sshIP would remain blank, and the provider would repeatedly attempt to ssh in and fail until timeout.

This fix will simply re-pull the container status from lxc until an sshIP address has been found, or 30 retries (15s) have passed.
- In my case, where remote-exec tries to access the container, another few retries allow "inet" ip_address to be successful propagated.
- In another case, where the sshIP address is not needed, the same occurs. A few retries occur, and the "inet" is propogated.
- Finally, if the container never generates an "inet" ip_address, this simply delays the resourceLxdContainerRead function from returning as expected by ~15s.