### PR TITLE
Provide clarity what happens when no lxd_remote has default = true

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ provider "lxd" {
     scheme   = "https"
     address  = "10.1.1.8"
     password = "password"
+    default  = true
   }
 
   lxd_remote {
@@ -86,6 +87,10 @@ The `lxd_remote` block supports:
 * `default` - *Optional* - Whether this should be the default remote. This
 	remote will then be used when one is not specified in a resource. Valid
 	values are `true` and `false`.
+  If you choose to _not_ set default=true on any `lxd_remote` this provider
+  will attempt to connect to an LXD server running on the same host through
+  the UNIX socket. See `Undefined Remote` for more information
+  The default can also be set with the `LXD_REMOTE` Environment variable.
 
 * `name` - *Optional* - The name of the LXD remote.
 


### PR DESCRIPTION
Hopefully this is self-explanatory. I have tried to stick to the existing conventions but let me know if you want it tweaked.

I found this really confusing when I took the example provided and started using different remotes. I had to look at the source code to work out why an lxd_profile was only being created locally. 

Interesting side node, there is no mention of the lxd_remote(s) being used when you run terraform [plan|refresh|apply]. I might raise this as a separate issue.