### PR TITLE
Fixes travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 
 go:
   - '1.10'
+  - '1.11'
   - master
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ go:
   - master
 
 before_script:
-  -  go get -t ./...
+  -  go get -v -d -t ./...
 
 script:
   - make fmtcheck

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ TARGETS=darwin linux windows
 default: build
 
 test:
-	go get ./...
-	go get github.com/dustinkirkland/golang-petname
+	go get -d -t ./...
 	go test -timeout 20m -v ./lxd
 
 testacc:


### PR DESCRIPTION
The build issue come from he fact that travis cannot compile lxd anymore, due to cgo dependencies.

~~This change forces us back to 3.4 until any of the following happen:~~
- lxd changes the repository, i am going to submit a PR for that (**Done**)
- ~~travis upgrades to xenial, but that seems to be after the heat dead of the universe~~
- ~~switching to a other CI/CD~~

dropped the lxd 3.4 change, this is pure build improvements now

