### PR TITLE
Build agains more target os/arch combinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-TARGETS=darwin linux windows
+TARGETS=netbsd/386 freebsd/amd64 netbsd/arm linux/amd64 netbsd/amd64 openbsd/amd64 freebsd/386 darwin/amd64 windows/amd64 darwin/386 freebsd/arm openbsd/386 windows/386
 
 default: build
 
@@ -14,11 +14,11 @@ testacc:
 build:
 	go build -v
 
-targets: $(TARGETS)
-
-$(TARGETS):
-	GOOS=$@ GOARCH=amd64 go build -o "dist/$@/terraform-provider-lxd_${TRAVIS_TAG}_x4"
-	zip -j dist/terraform-provider-lxd_${TRAVIS_TAG}_$@_amd64.zip dist/$@/terraform-provider-lxd_${TRAVIS_TAG}_x4
+targets:
+	gox -osarch='$(TARGETS)' -output="dist/{{.OS}}_{{.Arch}}/terraform-provider-lxd_${TRAVIS_TAG}_x4"
+	find dist -maxdepth 1 -mindepth 1 -type d -print0 | \
+	sed -z -e 's,^dist/,,' | \
+	xargs -0 --verbose --replace={} zip -r -j "dist/terraform-provider-lxd_${TRAVIS_TAG}_{}.zip" "dist/{}"
 
 dev:
 	go build -v
@@ -46,4 +46,4 @@ fmtcheck:
 		exit 1; \
 	fi
 
-.PHONY: build test testacc dev vet fmt fmtcheck targets $(TARGETS)
+.PHONY: build test testacc dev vet fmt fmtcheck targets

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-TARGETS=netbsd/386 freebsd/amd64 netbsd/arm linux/amd64 netbsd/amd64 openbsd/amd64 freebsd/386 darwin/amd64 windows/amd64 darwin/386 freebsd/arm openbsd/386 windows/386
+TARGETS=darwin/amd64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm openbsd/386 openbsd/amd64 windows/386 windows/amd64
 
 default: build
 


### PR DESCRIPTION
This change makes use of gox to compile more build targets. With some fixes on the side of lxd this should be able to build against almost all build targets available in gox.

Gox is using the multiple cpu cores available to speedup the build time

- Not building arm due to issues with compiling this plugin on travis
- build failures due to unrelated problem with travis building this plugin, a seperate PR to work arond that has been opened