### PR TITLE
#135: User opt-in to wait for network

### DIFF
--- a/docs/resources/lxd_container.md
+++ b/docs/resources/lxd_container.md
@@ -80,6 +80,9 @@ resource "lxd_container" "container1" {
 
 * `file` - *Optional* - File to upload to the container. See reference below.
 
+* `wait_for_network` - *Optional* - Boolean indicating if the provider should wait for the container's network address to become available during creation.
+  Valid values are `true` and `false`. Defaults to `false`.
+
 The `device` block supports:
 
 * `name` - *Required* - Name of the device.

--- a/docs/resources/lxd_container.md
+++ b/docs/resources/lxd_container.md
@@ -81,7 +81,7 @@ resource "lxd_container" "container1" {
 * `file` - *Optional* - File to upload to the container. See reference below.
 
 * `wait_for_network` - *Optional* - Boolean indicating if the provider should wait for the container's network address to become available during creation.
-  Valid values are `true` and `false`. Defaults to `false`.
+  Valid values are `true` and `false`. Defaults to `true`.
 
 The `device` block supports:
 

--- a/lxd/import_resource_lxd_container_test.go
+++ b/lxd/import_resource_lxd_container_test.go
@@ -24,7 +24,10 @@ func TestAccContainer_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     containerName + "/images:alpine/3.5/amd64",
+				ImportStateVerifyIgnore: []string{
+					"wait_for_network",
+				},
+				ImportStateId: containerName + "/images:alpine/3.5/amd64",
 			},
 		},
 	})
@@ -48,6 +51,7 @@ func TestAccContainer_importConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"image",
+					"wait_for_network",
 				},
 			},
 		},

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -101,7 +101,7 @@ func resourceLxdContainer() *schema.Resource {
 			"wait_for_network": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 				ForceNew: false,
 			},
 

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -98,6 +98,13 @@ func resourceLxdContainer() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"wait_for_network": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: false,
+			},
+
 			"privileged": &schema.Schema{
 				Type:       schema.TypeBool,
 				Optional:   true,
@@ -331,18 +338,20 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error waiting for container (%s) to become active: %s", name, err)
 	}
 
-	// Lxd will return "Running" even if the "inet" has not yet been set.
-	// wait until we see an "inet" ip_address before reading the state
-	networkConf := &resource.StateChangeConf{
-		Target:     []string{"OK"},
-		Refresh:    resourceLxdContainerWaitForNetwork(server, name),
-		Timeout:    3 * time.Minute,
-		Delay:      refreshInterval,
-		MinTimeout: 3 * time.Second,
-	}
+	if d.Get("wait_for_network").(bool) {
+		// Lxd will return "Running" even if "inet" has not yet been set.
+		// wait until we see an "inet" ip_address before reading the state.
+		networkConf := &resource.StateChangeConf{
+			Target:     []string{"OK"},
+			Refresh:    resourceLxdContainerWaitForNetwork(server, name),
+			Timeout:    3 * time.Minute,
+			Delay:      refreshInterval,
+			MinTimeout: 3 * time.Second,
+		}
 
-	if _, err = networkConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for container (%s) network information: %s", name, err)
+		if _, err = networkConf.WaitForState(); err != nil {
+			return fmt.Errorf("Error waiting for container (%s) network information: %s", name, err)
+		}
 	}
 
 	return resourceLxdContainerRead(d, meta)


### PR DESCRIPTION
Feature request #135
Add `wait_for_network` argument to lxd_container resource. This argument allows `resourceLxdContainerWaitForNetwork` to be opt-in instead of always-on.