### PR TITLE
Testing: Pinning Terraform to v0.11.10 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,10 @@ go:
   - master
 
 before_script:
-  -  go get -v -d -t ./...
+  - go get -v -d -t ./...
+  - cd $GOPATH/src/github.com/hashicorp/terraform
+  - git checkout v0.11.10
+  - cd -
 
 script:
   - make fmtcheck


### PR DESCRIPTION
There's no way to get around the errors being reported when compiling/testing against Terraform v0.12. Some of the errors are reporting problems with HCL fixtures when there's no problem.

For now, I propose doing all tests against v0.11.10.