### PR TITLE
Ensure Travis installs gox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ go:
   - master
 
 before_script:
+  - go get github.com/mitchellh/gox
   - go get -v -d -t ./...
   - cd $GOPATH/src/github.com/hashicorp/terraform
   - git checkout v0.11.10


### PR DESCRIPTION
The last release wasn't completed due to `gox` missing. This should fix the problem.