### PR TITLE
Update lxd_profile in docs

### DIFF
--- a/docs/resources/lxd_network.md
+++ b/docs/resources/lxd_network.md
@@ -34,6 +34,16 @@ resource "lxd_profile" "profile1" {
       parent  = "${lxd_network.new_default.name}"
     }
   }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties {
+      pool = "default"
+      path = "/"
+    }
+  }
 }
 
 resource "lxd_container" "test1" {
@@ -68,6 +78,16 @@ resource "lxd_profile" "profile1" {
     properties {
       nictype = "bridged"
       parent  = "${lxd_network.internal.name}"
+    }
+  }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties {
+      pool = "default"
+      path = "/"
     }
   }
 }

--- a/docs/resources/lxd_profile.md
+++ b/docs/resources/lxd_profile.md
@@ -21,6 +21,16 @@ resource "lxd_profile" "profile1" {
       path   = "/tmp"
     }
   }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties {
+      pool = "default"
+      path = "/"
+    }
+  }
 }
 
 resource "lxd_container" "test1" {


### PR DESCRIPTION
This commit updates the lxd_profile examples in the docs
to have an explicit root device defined.

Fixes #149 