### PR TITLE
Change Devices from TypeList to TypeSet

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -56,7 +56,7 @@ func resourceLxdContainer() *schema.Resource {
 			},
 
 			"device": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -445,6 +445,19 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	// Set the profiles used by the container
 	d.Set("profiles", container.Profiles)
 
+	// Set the devices used by the container
+	devices := make([]map[string]interface{}, 0)
+	for name, lxddevice := range container.Devices {
+		device := make(map[string]interface{})
+		device["name"] = name
+		delete(lxddevice, "name")
+		device["type"] = lxddevice["type"]
+		delete(lxddevice, "type")
+		device["properties"] = lxddevice
+		devices = append(devices, device)
+	}
+	d.Set("device", devices)
+
 	return nil
 }
 
@@ -564,7 +577,7 @@ func resourceLxdContainerUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	return nil
+	return resourceLxdContainerRead(d, meta)
 }
 
 func resourceLxdContainerDelete(d *schema.ResourceData, meta interface{}) (err error) {

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -168,7 +168,7 @@ func TestAccContainer_device(t *testing.T) {
 				Config: testAccContainer_device_1(containerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
-					resource.TestCheckResourceAttr("lxd_container.container1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_container.container1", "device.1834377448.properties.path", "/tmp/shared"),
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					testAccContainerDevice(&container, "shared", device1),
 				),
@@ -177,7 +177,7 @@ func TestAccContainer_device(t *testing.T) {
 				Config: testAccContainer_device_2(containerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
-					resource.TestCheckResourceAttr("lxd_container.container1", "device.0.properties.path", "/tmp/shared2"),
+					resource.TestCheckResourceAttr("lxd_container.container1", "device.2643642920.properties.path", "/tmp/shared2"),
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					testAccContainerDevice(&container, "shared", device2),
 				),
@@ -211,7 +211,7 @@ func TestAccContainer_addDevice(t *testing.T) {
 				Config: testAccContainer_addDevice_2(containerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
-					resource.TestCheckResourceAttr("lxd_container.container1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_container.container1", "device.1834377448.properties.path", "/tmp/shared"),
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					testAccContainerDevice(&container, "shared", device),
 				),
@@ -238,7 +238,7 @@ func TestAccContainer_removeDevice(t *testing.T) {
 				Config: testAccContainer_removeDevice_1(containerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
-					resource.TestCheckResourceAttr("lxd_container.container1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_container.container1", "device.1834377448.properties.path", "/tmp/shared"),
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					testAccContainerDevice(&container, "shared", device),
 				),

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -32,7 +32,7 @@ func resourceLxdProfile() *schema.Resource {
 			},
 
 			"device": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -190,7 +190,7 @@ func resourceLxdProfileUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return nil
+	return resourceLxdProfileRead(d, meta)
 }
 
 func resourceLxdProfileDelete(d *schema.ResourceData, meta interface{}) (err error) {

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -78,7 +78,7 @@ func TestAccProfile_device(t *testing.T) {
 				Config: testAccProfile_device_1(profileName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
-					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.1834377448.properties.path", "/tmp/shared"),
 					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
 					testAccProfileDevice(&profile, "shared", device1),
 				),
@@ -87,7 +87,7 @@ func TestAccProfile_device(t *testing.T) {
 				Config: testAccProfile_device_2(profileName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
-					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared2"),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.2643642920.properties.path", "/tmp/shared2"),
 					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
 					testAccProfileDevice(&profile, "shared", device2),
 				),
@@ -100,10 +100,16 @@ func TestAccProfile_addDevice(t *testing.T) {
 	var profile api.Profile
 	profileName := strings.ToLower(petname.Generate(2, "-"))
 
-	device := map[string]string{
+	device1 := map[string]string{
 		"type":   "disk",
 		"source": "/tmp",
-		"path":   "/tmp/shared",
+		"path":   "/tmp/shared1",
+	}
+
+	device2 := map[string]string{
+		"type":   "disk",
+		"source": "/tmp",
+		"path":   "/tmp/shared2",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -121,9 +127,19 @@ func TestAccProfile_addDevice(t *testing.T) {
 				Config: testAccProfile_addDevice_2(profileName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
-					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.3028205791.properties.path", "/tmp/shared1"),
 					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
-					testAccProfileDevice(&profile, "shared", device),
+					testAccProfileDevice(&profile, "shared1", device1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccProfile_addDevice_3(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.1620449630.properties.path", "/tmp/shared2"),
+					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
+					testAccProfileDevice(&profile, "shared1", device1),
+					testAccProfileDevice(&profile, "shared2", device2),
 				),
 			},
 		},
@@ -148,7 +164,7 @@ func TestAccProfile_removeDevice(t *testing.T) {
 				Config: testAccProfile_removeDevice_1(profileName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
-					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.1834377448.properties.path", "/tmp/shared"),
 					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
 					testAccProfileDevice(&profile, "shared", device),
 				),
@@ -212,7 +228,7 @@ func TestAccProfile_containerDevice(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
-					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.0.properties.path", "/tmp/shared"),
+					resource.TestCheckResourceAttr("lxd_profile.profile1", "device.1834377448.properties.path", "/tmp/shared"),
 					testAccProfileRunning(t, "lxd_profile.profile1", &profile),
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					testAccProfileDevice(&profile, "shared", device),
@@ -371,11 +387,37 @@ resource "lxd_profile" "profile1" {
   name = "%s"
 
   device {
-    name = "shared"
+    name = "shared1"
     type = "disk"
     properties {
       source = "/tmp"
-      path = "/tmp/shared"
+      path = "/tmp/shared1"
+    }
+  }
+}
+	`, name)
+}
+
+func testAccProfile_addDevice_3(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_profile" "profile1" {
+  name = "%s"
+
+  device {
+    name = "shared2"
+    type = "disk"
+    properties {
+      source = "/tmp"
+      path = "/tmp/shared2"
+    }
+  }
+
+  device {
+    name = "shared1"
+    type = "disk"
+    properties {
+      source = "/tmp"
+      path = "/tmp/shared1"
     }
   }
 }

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccVolumeContainerAttach_basic(t *testing.T) {
+	t.Skip("lxd_volume_container_attach is deprecated and will be removed in the future")
+
 	poolName := strings.ToLower(petname.Generate(2, "-"))
 	volumeName := strings.ToLower(petname.Generate(2, "-"))
 	containerName := strings.ToLower(petname.Generate(2, "-"))
@@ -34,6 +36,8 @@ func TestAccVolumeContainerAttach_basic(t *testing.T) {
 }
 
 func TestAccVolumeContainerAttach_deviceName(t *testing.T) {
+	t.Skip("lxd_volume_container_attach is deprecated and will be removed in the future")
+
 	poolName := strings.ToLower(petname.Generate(2, "-"))
 	volumeName := strings.ToLower(petname.Generate(2, "-"))
 	containerName := strings.ToLower(petname.Generate(2, "-"))

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	lxd "github.com/lxc/lxd/client"
 	"github.com/mitchellh/go-homedir"
 )
@@ -119,7 +120,9 @@ func resourceLxdConfigMapAppend(config map[string]string, append interface{}, na
 
 func resourceLxdDevices(d interface{}) map[string]map[string]string {
 	devices := make(map[string]map[string]string)
-	for _, v := range d.([]interface{}) {
+
+	rawDevices := d.(*schema.Set).List()
+	for _, v := range rawDevices {
 		device := make(map[string]string)
 		d := v.(map[string]interface{})
 		deviceName := d["name"].(string)


### PR DESCRIPTION
I was reviewing #138 and discovered that LXD does not report devices in any order. Sorting the results will only help if the user has defined their devices already sorted.

Unfortunately we will need to change devices from `TypeList` to `TypeSet`. If users are referencing devices using an index-based notation, this is going to break those references.

Commit message follows:

LXD does not return a container or profile's devices in a
set order. This causes random, sometimes perpetual, state
changes to occur.

The only way to resolve this issue is by changing the schema
type of devices from TypeList to TypeSet.