### PR TITLE
Fix creation_date / created_at

### DIFF
--- a/docs/resources/lxd_snapshot.md
+++ b/docs/resources/lxd_snapshot.md
@@ -28,5 +28,8 @@ resource "lxd_snapshot" "snap1" {
 
 The following attributes are exported:
 
-* `creation_date` - The time LXD reported the snapshot was successfully
-	created, in UTC.
+* `creation_date` - **Deprecated - use `created_at` instead** - The time LXD
+  reported the snapshot was successfully created, in UTC.
+
+* `created_at` - The time LXD  reported the snapshot was successfully created,
+  in UTC.

--- a/lxd/import_resource_lxd_container_test.go
+++ b/lxd/import_resource_lxd_container_test.go
@@ -27,7 +27,7 @@ func TestAccContainer_importBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"wait_for_network",
 				},
-				ImportStateId: containerName + "/images:alpine/3.5/amd64",
+				ImportStateId: containerName + "/images:alpine/3.9/amd64",
 			},
 		},
 	})

--- a/lxd/resource_lxd_cached_image_test.go
+++ b/lxd/resource_lxd_cached_image_test.go
@@ -72,7 +72,7 @@ func TestAccCachedImage_copiedAlias(t *testing.T) {
 					resourceAccCachedImageCheckAttributes("lxd_cached_image.img3", &img),
 					testAccCachedImageContainsAlias(&img, alias1),
 					testAccCachedImageContainsAlias(&img, alias2),
-					testAccCachedImageContainsAlias(&img, "alpine/3.5"),
+					testAccCachedImageContainsAlias(&img, "alpine/3.9"),
 				),
 			},
 		},
@@ -91,7 +91,7 @@ func TestAccCachedImage_aliasCollision(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCachedImageExists(t, "lxd_cached_image.img4", &img),
 					resourceAccCachedImageCheckAttributes("lxd_cached_image.img4", &img),
-					testAccCachedImageContainsAlias(&img, "alpine/3.5/amd64"),
+					testAccCachedImageContainsAlias(&img, "alpine/3.9/amd64"),
 				),
 			},
 		},
@@ -243,7 +243,7 @@ func testAccCachedImage_basic() string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img1" {
   source_remote = "images"
-  source_image = "alpine/3.5"
+  source_image = "alpine/3.9"
 
   copy_aliases = true
 }
@@ -254,7 +254,7 @@ func testAccCachedImage_aliases(aliases ...string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img2" {
   source_remote = "images"
-  source_image = "alpine/3.5/i386"
+  source_image = "alpine/3.9/i386"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -266,7 +266,7 @@ func testAccCachedImage_aliasExists1(alias string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "exists1" {
   source_remote = "images"
-  source_image = "alpine/3.5/i386"
+  source_image = "alpine/3.9/i386"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -278,7 +278,7 @@ func testAccCachedImage_aliasExists2(alias string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "exists1" {
   source_remote = "images"
-  source_image = "alpine/3.5/i386"
+  source_image = "alpine/3.9/i386"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -286,7 +286,7 @@ resource "lxd_cached_image" "exists1" {
 
 resource "lxd_cached_image" "exists2" {
   source_remote = "images"
-  source_image = "alpine/3.5/amd64"
+  source_image = "alpine/3.9/amd64"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -298,9 +298,9 @@ func testAccCachedImage_aliases2(aliases ...string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img3" {
   source_remote = "images"
-  source_image = "alpine/3.5"
+  source_image = "alpine/3.9"
 
-  aliases = ["alpine/3.5","%s"]
+  aliases = ["alpine/3.9","%s"]
   copy_aliases = true
 }
 	`, strings.Join(aliases, `","`))
@@ -310,9 +310,9 @@ func testAccCachedImage_aliasCollision() string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img4" {
   source_remote = "images"
-  source_image = "alpine/3.5/amd64"
+  source_image = "alpine/3.9/amd64"
 
-  aliases = ["alpine/3.5/amd64"]
+  aliases = ["alpine/3.9/amd64"]
   copy_aliases = true
 }
 	`)

--- a/lxd/resource_lxd_container_file_test.go
+++ b/lxd/resource_lxd_container_file_test.go
@@ -91,7 +91,7 @@ func testAccContainerFile_content(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 }
 
@@ -108,7 +108,7 @@ func testAccContainerFile_source(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 }
 

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -520,7 +520,7 @@ func testAccContainer_basic(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -530,7 +530,7 @@ func testAccContainer_config(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
   config {
     boot.autostart = 1
@@ -547,7 +547,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 	`, profileName, containerName)
@@ -561,7 +561,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -575,7 +575,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -589,7 +589,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 	`, profileName, containerName)
@@ -599,7 +599,7 @@ func testAccContainer_device_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   device {
@@ -618,7 +618,7 @@ func testAccContainer_device_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   device {
@@ -637,7 +637,7 @@ func testAccContainer_addDevice_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -647,7 +647,7 @@ func testAccContainer_addDevice_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   device {
@@ -666,7 +666,7 @@ func testAccContainer_removeDevice_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   device {
@@ -685,7 +685,7 @@ func testAccContainer_removeDevice_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -695,7 +695,7 @@ func testAccContainer_fileUploadContent_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   file {
@@ -712,7 +712,7 @@ func testAccContainer_fileUploadContent_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   file {
@@ -729,7 +729,7 @@ func testAccContainer_fileUploadSource(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   file {
@@ -746,7 +746,7 @@ func testAccContainer_remoteImage(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -756,7 +756,7 @@ func testAccContainer_defaultProfile(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
 }
 	`, name)
 }
@@ -765,7 +765,7 @@ func testAccContainer_configLimits_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   limits {
@@ -779,7 +779,7 @@ func testAccContainer_configLimits_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   limits {
@@ -815,7 +815,7 @@ resource "lxd_network" "network_2" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   config {

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -188,7 +188,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 `, profileName, containerName)

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -460,7 +460,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -482,7 +482,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)

--- a/lxd/resource_lxd_snapshot.go
+++ b/lxd/resource_lxd_snapshot.go
@@ -39,6 +39,12 @@ func resourceLxdSnapshot() *schema.Resource {
 			},
 
 			"creation_date": &schema.Schema{
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use created_at instead",
+			},
+
+			"created_at": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -125,7 +131,8 @@ func resourceLxdSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("container_name", snapID.container)
 	d.Set("name", snapID.snapshot)
 	d.Set("stateful", snap.Stateful)
-	d.Set("creation_date", snap.CreationDate.String())
+	d.Set("creation_date", snap.CreatedAt.String())
+	d.Set("created_at", snap.CreatedAt.String())
 
 	return nil
 }

--- a/lxd/resource_lxd_snapshot_test.go
+++ b/lxd/resource_lxd_snapshot_test.go
@@ -149,7 +149,7 @@ func testAccSnapshot_basic(cName, sName string, stateful bool) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 
@@ -165,7 +165,7 @@ func testAccSnapshot_multiple1(cName, sName string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 
@@ -181,7 +181,7 @@ func testAccSnapshot_multiple2(cName, sName1, sName2 string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -101,7 +101,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 
@@ -131,7 +131,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5"
+  image = "images:alpine/3.9"
   profiles = ["default"]
 }
 

--- a/lxd/resource_lxd_volume_test.go
+++ b/lxd/resource_lxd_volume_test.go
@@ -137,7 +137,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.5/amd64"
+  image = "images:alpine/3.9/amd64"
   profiles = ["default"]
 
   device {


### PR DESCRIPTION
The LXD snapshot field CreationDate has been renamed to CreatedAt.
This commit changes the value of the creation_date attribute to
use the new CreatedAt field. It also adds a new created_at attribute
and deprecates the older creation_date attribute.