### PR TITLE
Fix typo.

### DIFF
--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -21,5 +21,5 @@
 ### Storage
 
 * [`lxd_storage_pool`](lxd_storage_pool.md)
-* [`lxd_volume`](lxd_cached_image.md)
+* [`lxd_volume`](lxd_volume.md)
 * [`lxd_volume_container_attach`](lxd_volume_container_attach.md) *DEPRECATED*


### PR DESCRIPTION
The `lxd_volume` link is pointing to `lxd_cached_image`.