### PR TITLE
Expose containers IPv6 address

### DIFF
--- a/docs/resources/lxd_container.md
+++ b/docs/resources/lxd_container.md
@@ -117,8 +117,14 @@ The `file` block supports:
 
 The following attributes are exported:
 
-* `ip_address` - The IP Address of the container. See Container Network Access
+* `ip_address` - The IPv4 Address of the container. See Container Network Access
   for more details.
+
+* `ipv4_address` - The IPv4 Address of the container. See Container Network
+  Access for more details.
+
+* `ipv6_address` - The IPv6 Address of the container. See Container Network
+  Access for more details.
 
 * `mac_address` - The MAC address of the detected NIC. See Container Network
   Access for more details.
@@ -128,8 +134,8 @@ The following attributes are exported:
 ## Container Network Access
 
 If your container has multiple network interfaces, you can specify which one
-Terraform should report the IP address of. If you do not specify an interface,
-Terraform will use the _last_ one detected.
+Terraform should report the IP addresses of. If you do not specify an interface,
+Terraform will use the _last_ IPv4 address detected and the IPv6 address with the shortest text representation.
 
 To specify an interface, do the following:
 

--- a/docs/resources/lxd_container.md
+++ b/docs/resources/lxd_container.md
@@ -135,7 +135,7 @@ The following attributes are exported:
 
 If your container has multiple network interfaces, you can specify which one
 Terraform should report the IP addresses of. If you do not specify an interface,
-Terraform will use the _last_ IPv4 address detected and the IPv6 address with the shortest text representation.
+Terraform will use the _last_ address detected. Global IPv6 address will be favored if present.
 
 To specify an interface, do the following:
 

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -162,6 +162,18 @@ func resourceLxdContainer() *schema.Resource {
 				ForceNew: false,
 			},
 
+			"ipv4_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: false,
+			},
+
+			"ipv6_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: false,
+			},
+
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -414,8 +426,16 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 			if ip.Family == "inet" {
 				aiFound = true
 				d.Set("ip_address", ip.Address)
+				d.Set("ipv4_address", ip.Address)
 				sshIP = ip.Address
 				d.Set("mac_address", net.Hwaddr)
+			}
+		}
+
+		for _, ip := range net.Addresses {
+			if ip.Family == "inet6" && ip.Scope == "global" {
+				d.Set("ipv6_address", ip.Address)
+				break
 			}
 		}
 	}
@@ -428,8 +448,16 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 				for _, ip := range net.Addresses {
 					if ip.Family == "inet" {
 						d.Set("ip_address", ip.Address)
+						d.Set("ipv4_address", ip.Address)
 						sshIP = ip.Address
 						d.Set("mac_address", net.Hwaddr)
+					}
+				}
+
+				for _, ip := range net.Addresses {
+					if ip.Family == "inet6" && ip.Scope == "global" {
+						d.Set("ipv6_address", ip.Address)
+						break
 					}
 				}
 			}

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -358,6 +358,8 @@ func TestAccContainer_accessInterface(t *testing.T) {
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
 					resource.TestCheckResourceAttr("lxd_container.container1", "ip_address", "10.150.19.200"),
+					resource.TestCheckResourceAttr("lxd_container.container1", "ipv4_address", "10.150.19.200"),
+					resource.TestCheckResourceAttr("lxd_container.container1", "ipv6_address", "fd42:474b:622d:259d:216:3eff:fe39:7f36"),
 				),
 			},
 		},
@@ -836,6 +838,7 @@ resource "lxd_container" "container1" {
     properties = {
       nictype = "bridged"
       parent = "${lxd_network.network_1.name}"
+      hwaddr = "00:16:3e:39:7f:36"
       "ipv4.address" = "10.150.19.200"
     }
   }


### PR DESCRIPTION
This exposes two new container properties, `ipv4_address` and `ipv6_address`. The first one contains the same IPv4 address as in `ip_address`. The second property exports the containers IPv6 address.

The IPv6 address with the shortest representation is chosen, this should favor usual static addresses (e.g. `2001:db8::1234`) over dynamic addresses. I'm not sure if and how this can be integrated into `wait_for_network`, right now it does not wait explicitly for any IPv6 address. I had no problems yet.

Example:

```tf
resource "lxd_container" "mail" {
  name     = "mail"
  image    = "ubuntu"
}

resource "dns_aaaa_record_set" "public_mail_example_org" {
  zone      = "example.org."
  name      = "mail"
  addresses = [lxd_container.mail.ipv6_address]
}
```