### PR TITLE
Fix Device Name Deletion

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -450,7 +450,6 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	for name, lxddevice := range container.Devices {
 		device := make(map[string]interface{})
 		device["name"] = name
-		delete(lxddevice, "name")
 		device["type"] = lxddevice["type"]
 		delete(lxddevice, "type")
 		device["properties"] = lxddevice


### PR DESCRIPTION
This commit fixes a bug where the name attribute within a
device's properties was being deleted due to it being confused
with the device name itself.

For #171 