### PR TITLE
Fix absence of linux.* attribute in config

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -405,6 +405,8 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 			config[k] = v
 		} else if strings.HasPrefix(k, "raw.") {
 			config[k] = v
+		} else if strings.HasPrefix(k, "linux.") {
+			config[k] = v
 		} else if strings.HasPrefix(k, "security.") {
 			config[k] = v
 		} else if strings.HasPrefix(k, "user.") {


### PR DESCRIPTION
Added support for linux.kernel_modules attribute in config section.

Fixes #193 
