### PR TITLE
Adds new resource lxd_publish_image

### DIFF
--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -3,6 +3,7 @@
 ### Image
 
 * [`lxd_cached_image`](lxd_cached_image.md)
+* [`lxd_publish_image`](lxd_publish_image.md)
 
 ### Container
 

--- a/docs/resources/lxd_publish_image.md
+++ b/docs/resources/lxd_publish_image.md
@@ -1,0 +1,50 @@
+# lxd_publish_image
+
+Create a LXD image from a container
+
+## Example Usage
+
+```hcl
+resource "lxd_cached_image" "xenial" {
+  source_remote = "ubuntu"
+  source_image  = "xenial/amd64"
+}
+
+resource "lxd_container" "test1" {
+  name      = "test1"
+  image     = "${lxd_cached_image.xenial.fingerprint}"
+  profiles  = ["default"]
+
+  start_container = false
+}
+
+resource "lxd_publish_image" "test1" {
+  depends_on = [ lxd_container.test1 ]
+
+  container = "test1"
+  aliases   = [ "test1_img" ]
+}
+
+```
+
+## Argument Reference
+
+* `container` - *Required* - The name of the container
+
+* `aliases` - *Optional* - A list of aliases to assign to the image 
+
+* `properties` - *Optional* - A map of properties to assign to the image 
+
+* `public` - *Optional* - Whether the image can be downloaded by untrusted users.
+	Valid values are `true` and `false`. Defaults to `false`.
+
+* `filename` - *Optional* - Used for export
+
+* `compression_algorithm` - *Optional* - Override the compression algorithm for the image. 
+    Valid values are (`bzip2`, `gzip`, `lzma`, `xz` or `none`). Defaults to `gzip`
+
+* `triggers` - *Optional* - A map of arbitrary strings that, when changed, will force the resource to be replaced.
+
+## Notes
+
+* The container must be stopped

--- a/lxd/import_resource_lxd_container_test.go
+++ b/lxd/import_resource_lxd_container_test.go
@@ -26,6 +26,7 @@ func TestAccContainer_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"wait_for_network",
+					"start_container",
 				},
 				ImportStateId: containerName + "/images:alpine/3.9/amd64",
 			},
@@ -52,6 +53,7 @@ func TestAccContainer_importConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"image",
 					"wait_for_network",
+					"start_container",
 				},
 			},
 		},

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -188,6 +188,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"lxd_cached_image":            resourceLxdCachedImage(),
+			"lxd_publish_image":           resourceLxdPublishImage(),
 			"lxd_container":               resourceLxdContainer(),
 			"lxd_container_file":          resourceLxdContainerFile(),
 			"lxd_network":                 resourceLxdNetwork(),

--- a/lxd/resource_lxd_publish_image.go
+++ b/lxd/resource_lxd_publish_image.go
@@ -1,0 +1,262 @@
+package lxd
+
+import (
+	"fmt"
+	"log"
+
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/lxc/lxd/shared/api"
+)
+
+func resourceLxdPublishImage() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLxdPublishImageCreate,
+		Update: resourceLxdPublishImageUpdate,
+		Delete: resourceLxdCachedImageDelete,
+		Exists: resourceLxdCachedImageExists,
+		Read:   resourceLxdPublishImageRead,
+
+		Schema: map[string]*schema.Schema{
+			"container": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"aliases": {
+				Type:     schema.TypeList,
+				ForceNew: false,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: false,
+			},
+			"public": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+				ForceNew: true,
+			},
+			"filename": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"compression_algorithm": {
+				Type:     schema.TypeString,
+				Default:  "gzip",
+				Optional: true,
+				ForceNew: true,
+			},
+			"triggers": {
+				Description: "A map of arbitrary strings that, when changed, will force the resource to be replaced.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceLxdPublishImageCreate(d *schema.ResourceData, meta interface{}) error {
+	p := meta.(*lxdProvider)
+
+	dstName := p.selectRemote(d)
+	dstServer, err := p.GetInstanceServer(dstName)
+	if err != nil {
+		return err
+	}
+
+	container := d.Get("container").(string)
+	ct, _, err := dstServer.GetContainerState(container)
+	if err != nil && err.Error() == "not found" {
+		return err
+	}
+
+	if ct.StatusCode != api.Stopped {
+		return fmt.Errorf("Container is running")
+	}
+
+	aliases := make([]api.ImageAlias, 0)
+	if v, ok := d.GetOk("aliases"); ok {
+		for _, alias := range v.([]interface{}) {
+			// Check image alias doesn't already exist on destination
+			dstAliasTarget, _, _ := dstServer.GetImageAlias(alias.(string))
+			if dstAliasTarget != nil {
+				return fmt.Errorf("Image alias already exists on destination: %s", alias.(string))
+			}
+
+			ia := api.ImageAlias{
+				Name: alias.(string),
+			}
+
+			aliases = append(aliases, ia)
+		}
+	}
+
+	properties := resourceLxdConfigMap(d.Get("properties"))
+	public := d.Get("public").(bool)
+	filename := d.Get("filename").(string)
+	compressionAlgorithm := d.Get("compression_algorithm").(string)
+
+	// Execute the copy
+	// Image copy arguments
+	req := api.ImagesPost{
+		Filename: filename,
+		Aliases:  aliases,
+		ImagePut: api.ImagePut{
+			Public:     public,
+			Properties: properties,
+		},
+		Source: &api.ImagesPostSource{
+			Type: "container",
+			Name: container,
+		},
+		CompressionAlgorithm: compressionAlgorithm,
+	}
+
+	op, err := dstServer.CreateImage(req, nil)
+	if err != nil {
+		return err
+	}
+
+	// Wait for operation to finish
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	opAPI := op.Get()
+
+	// Grab the fingerprint
+	fingerprint := opAPI.Metadata["fingerprint"].(string)
+
+	// Image was successfully copied, set resource ID
+	id := newPublishImageID(dstName, fingerprint)
+	d.SetId(id.resourceID())
+
+	return resourceLxdPublishImageRead(d, meta)
+}
+
+func resourceLxdPublishImageUpdate(d *schema.ResourceData, meta interface{}) error {
+	p := meta.(*lxdProvider)
+	remote := p.selectRemote(d)
+	server, err := p.GetInstanceServer(remote)
+	if err != nil {
+		return err
+	}
+	id := newPublishImageIDFromResourceID(d.Id())
+
+	if d.HasChange("aliases") {
+		old, new := d.GetChange("aliases")
+		oldSet := schema.NewSet(schema.HashString, old.([]interface{}))
+		newSet := schema.NewSet(schema.HashString, new.([]interface{}))
+		aliasesToRemove := oldSet.Difference(newSet)
+		aliasesToAdd := newSet.Difference(oldSet)
+
+		// Delete removed
+		for _, a := range aliasesToRemove.List() {
+			alias := a.(string)
+			err := server.DeleteImageAlias(alias)
+			if err != nil {
+				return err
+			}
+		}
+		// Add new
+		for _, a := range aliasesToAdd.List() {
+			alias := a.(string)
+
+			req := api.ImageAliasesPost{}
+			req.Name = alias
+			req.Target = id.fingerprint
+
+			err := server.CreateImageAlias(req)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if d.HasChange("properties") {
+		properties := resourceLxdConfigMap(d.Get("properties"))
+
+		req := api.ImagePut{
+			Properties: properties,
+		}
+
+		err := server.UpdateImage(id.fingerprint, req, "")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceLxdPublishImageRead(d *schema.ResourceData, meta interface{}) error {
+	p := meta.(*lxdProvider)
+	remote := p.selectRemote(d)
+	server, err := p.GetImageServer(remote)
+	if err != nil {
+		return err
+	}
+
+	id := newPublishImageIDFromResourceID(d.Id())
+
+	img, _, err := server.GetImage(id.fingerprint)
+	if err != nil {
+		if err.Error() == "not found" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("fingerprint", id.fingerprint)
+	d.Set("architecture", img.Architecture)
+	d.Set("created_at", img.CreatedAt.Unix())
+
+	var aliases []string
+	configAliases := d.Get("aliases").([]interface{})
+	configSet := schema.NewSet(schema.HashString, configAliases)
+
+	for _, a := range img.Aliases {
+		if configSet.Contains(a.Name) {
+			aliases = append(aliases, a.Name)
+		} else {
+			log.Println("[DEBUG] filtered alias ", a)
+		}
+	}
+	d.Set("aliases", aliases)
+	d.Set("properties", img.Properties)
+
+	return nil
+}
+
+type publishImageID struct {
+	remote      string
+	fingerprint string
+}
+
+func newPublishImageID(remote, fingerprint string) publishImageID {
+	return publishImageID{
+		remote:      remote,
+		fingerprint: fingerprint,
+	}
+}
+
+func newPublishImageIDFromResourceID(id string) publishImageID {
+	parts := strings.SplitN(id, "/", 2)
+	return publishImageID{
+		remote:      parts[0],
+		fingerprint: parts[1],
+	}
+}
+
+func (id publishImageID) resourceID() string {
+	return fmt.Sprintf("%s/%s", id.remote, id.fingerprint)
+}

--- a/lxd/resource_lxd_publish_image_test.go
+++ b/lxd/resource_lxd_publish_image_test.go
@@ -1,0 +1,230 @@
+package lxd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+func TestAccPublishImage_basic(t *testing.T) {
+	var container api.Container
+	var img api.Image
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublishImage_basic(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerState(t, "lxd_container.container1", &container, api.Stopped),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					testAccCachedImageExists(t, "lxd_publish_image.test_basic", &img),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPublishImage_aliases(t *testing.T) {
+	var container api.Container
+	var img api.Image
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	aliases := []interface{}{"alias1", "alias2"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublishImage_aliases(containerName, aliases),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerState(t, "lxd_container.container1", &container, api.Stopped),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					testAccCachedImageExists(t, "lxd_publish_image.test_basic", &img),
+					testAccPublishImageHasAliases(&img, aliases),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPublishImage_properties(t *testing.T) {
+	var container api.Container
+	var img api.Image
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	properties := map[string]string{"os": "Alpine", "version": "4"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublishImage_properties(containerName, properties),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerState(t, "lxd_container.container1", &container, api.Stopped),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					testAccCachedImageExists(t, "lxd_publish_image.test_basic", &img),
+					testAccPublishImageHasProperties(&img, properties),
+				),
+			},
+		},
+	})
+}
+
+func testAccPublishImage_basic(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.9/amd64"
+  profiles = ["default"]
+
+  start_container = false
+}
+
+resource "lxd_publish_image" "test_basic" {
+  depends_on = [ lxd_container.container1 ]
+
+  container = "%s"
+  aliases = [ "test_basic" ]
+}
+	`, name, name)
+}
+
+func testAccPublishImage_aliases(name string, aliases []interface{}) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.9/amd64"
+  profiles = ["default"]
+
+  start_container = false
+}
+
+resource "lxd_publish_image" "test_basic" {
+  depends_on = [ lxd_container.container1 ]
+
+  container = "%s"
+  aliases = [ "%s" ]
+}
+	`, name, name, strings.Join(toStringSlice(aliases), "\",\""))
+}
+
+func testAccPublishImage_properties(name string, properties map[string]string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.9/amd64"
+  profiles = ["default"]
+
+  start_container = false
+}
+
+resource "lxd_publish_image" "test_basic" {
+  depends_on = [ lxd_container.container1 ]
+
+  container = "%s"
+  properties = {
+  	%s
+  }
+}
+	`, name, name, strings.Join(formatProperties(properties), "\n"))
+}
+
+func testAccPublishImageExists(t *testing.T, n string, image *api.Image) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found in state: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		id := newPublishImageIDFromResourceID(rs.Primary.ID)
+		client, err := testAccProvider.Meta().(*lxdProvider).GetInstanceServer("")
+		if err != nil {
+			return err
+		}
+		img, _, err := client.GetImage(id.fingerprint)
+		if err != nil {
+			return err
+		}
+
+		if img != nil {
+			*image = *img
+			return nil
+		}
+
+		return fmt.Errorf("Image not found: %s", rs.Primary.ID)
+	}
+}
+
+func testAccPublishImageHasAliases(img *api.Image, aliases []interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if img.Aliases == nil || len(img.Aliases) == 0 {
+			return fmt.Errorf("No aliases")
+		}
+
+		aliasSet := schema.NewSet(schema.HashString, aliases)
+		found := 0
+
+		for _, a := range img.Aliases {
+			if aliasSet.Contains(a.Name) {
+				found++
+			}
+		}
+
+		if found != len(aliases) {
+			return fmt.Errorf("The aliases doesn't match")
+		}
+
+		return nil
+	}
+}
+
+func testAccPublishImageHasProperties(img *api.Image, properties map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if img.Properties == nil || len(img.Properties) == 0 {
+			return fmt.Errorf("No properties")
+		}
+
+		for k, v := range img.Properties {
+			if vv, ok := properties[k]; ok && v == vv {
+				continue
+			} else {
+				return fmt.Errorf("Property %s does not match", k)
+			}
+		}
+
+		return nil
+	}
+}
+
+func toStringSlice(v []interface{}) []string {
+	r := make([]string, len(v))
+	for i, v := range v {
+		r[i] = v.(string)
+	}
+	return r
+}
+
+func formatProperties(properties map[string]string) []string {
+	r := make([]string, 0, len(properties))
+	for k, v := range properties {
+		r = append(r, fmt.Sprintf(`"%s":"%s"`, k, v))
+	}
+	return r
+}


### PR DESCRIPTION
I have added a new resource that makes it possible to create a LXD image from a stopped container. Possible through lxc with `lxc publish`