### PR TITLE
Allow updating networks in-place

### DIFF
--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -81,6 +81,34 @@ func TestAccNetwork_attach(t *testing.T) {
 	})
 }
 
+func TestAccNetwork_updateConfig(t *testing.T) {
+	var network api.Network
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetwork_updateConfig_1(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetworkExists(t, "lxd_network.eth1", &network),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "config.ipv4.address", "10.150.19.1/24"),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "config.ipv4.nat", "true"),
+				),
+			},
+			{
+				Config: testAccNetwork_updateConfig_2(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetworkExists(t, "lxd_network.eth1", &network),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "config.ipv4.address", "10.150.21.1/24"),
+					resource.TestCheckResourceAttr("lxd_network.eth1", "config.ipv4.nat", "false"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNetworkExists(t *testing.T, n string, network *api.Network) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -147,8 +175,8 @@ resource "lxd_network" "eth1" {
 func testAccNetwork_desc() string {
 	return fmt.Sprintf(`
 resource "lxd_network" "eth1" {
-	name        = "eth1"
-	description = "descriptive"
+  name        = "eth1"
+  description = "descriptive"
 
   config = {
     "ipv4.address" = "10.150.19.1/24"
@@ -192,4 +220,68 @@ resource "lxd_container" "container1" {
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 `, profileName, containerName)
+}
+
+func testAccNetwork_updateConfig_1(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_network" "eth1" {
+  name = "eth1"
+
+  config = {
+    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.nat" = "true"
+    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.nat" = "true"
+  }
+}
+
+# We do need a container here to ensure the network cannot
+# be deleted, but must be updated in-place.
+resource "lxd_container" "c1" {
+  name             = "%s"
+  image            = "images:alpine/3.9"
+  wait_for_network = false
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      nictype = "bridged"
+      parent  = lxd_network.eth1.name
+    }
+  }
+}
+  `, name)
+}
+
+func testAccNetwork_updateConfig_2(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_network" "eth1" {
+  name = "eth1"
+
+  config = {
+    "ipv4.address" = "10.150.21.1/24"
+    "ipv4.nat" = "false"
+    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.nat" = "true"
+  }
+}
+
+# We do need a container here to ensure the network cannot
+# be deleted, but must be updated in-place.
+resource "lxd_container" "c1" {
+  name             = "%s"
+  image            = "images:alpine/3.9"
+  wait_for_network = false
+
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      nictype = "bridged"
+      parent  = lxd_network.eth1.name
+    }
+  }
+}
+  `, name)
 }


### PR DESCRIPTION
This PR adds an update method to the network resource that applies config changes without recreating the network. This allows updating networks that are in use.
