### PR TITLE
Add target attribute to container resource for LXD cluster

### DIFF
--- a/docs/resources/lxd_container.md
+++ b/docs/resources/lxd_container.md
@@ -83,6 +83,8 @@ resource "lxd_container" "container1" {
 * `wait_for_network` - *Optional* - Boolean indicating if the provider should wait for the container's network address to become available during creation.
   Valid values are `true` and `false`. Defaults to `true`.
 
+* `target` - *Optional* - Specify a target node in a cluster.
+
 The `device` block supports:
 
 * `name` - *Required* - Name of the device.

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -40,6 +40,13 @@ func resourceLxdContainer() *schema.Resource {
 				Default:  "",
 			},
 
+			"target": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+
 			"image": {
 				Type:             schema.TypeString,
 				ForceNew:         true,
@@ -271,6 +278,11 @@ func resourceLxdContainerCreate(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
+	// Use specific target node in a cluster
+	if target, ok := d.GetOk("target"); ok && target != "" {
+		server = server.UseTarget(target.(string))
+	}
+
 	// Create container. It will not be running after this operation
 	op1, err := server.CreateContainerFromImage(imgServer, *imgInfo, createReq)
 	if err != nil {
@@ -402,6 +414,7 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("ephemeral", container.Ephemeral)
 	d.Set("privileged", false) // Create has no handling for it yet
+	d.Set("target", container.Location)
 
 	config := make(map[string]string)
 	limits := make(map[string]string)


### PR DESCRIPTION
The target attributes allows placing a container on a specific node in a LXD cluster.

---

I have not found a useful way for testing without setting up a multi-node LXD cluster. Are you fine with skipping tests here?