### PR TITLE
Update alpine image used in tests

### DIFF
--- a/lxd/import_resource_lxd_container_test.go
+++ b/lxd/import_resource_lxd_container_test.go
@@ -28,7 +28,7 @@ func TestAccContainer_importBasic(t *testing.T) {
 					"wait_for_network",
 					"start_container",
 				},
-				ImportStateId: containerName + "/images:alpine/3.9/amd64",
+				ImportStateId: containerName + "/images:alpine/3.12/amd64",
 			},
 		},
 	})

--- a/lxd/resource_lxd_cached_image_test.go
+++ b/lxd/resource_lxd_cached_image_test.go
@@ -72,7 +72,7 @@ func TestAccCachedImage_copiedAlias(t *testing.T) {
 					resourceAccCachedImageCheckAttributes("lxd_cached_image.img3", &img),
 					testAccCachedImageContainsAlias(&img, alias1),
 					testAccCachedImageContainsAlias(&img, alias2),
-					testAccCachedImageContainsAlias(&img, "alpine/3.9"),
+					testAccCachedImageContainsAlias(&img, "alpine/3.12"),
 				),
 			},
 		},
@@ -91,7 +91,7 @@ func TestAccCachedImage_aliasCollision(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCachedImageExists(t, "lxd_cached_image.img4", &img),
 					resourceAccCachedImageCheckAttributes("lxd_cached_image.img4", &img),
-					testAccCachedImageContainsAlias(&img, "alpine/3.9/amd64"),
+					testAccCachedImageContainsAlias(&img, "alpine/3.12/amd64"),
 				),
 			},
 		},
@@ -243,7 +243,7 @@ func testAccCachedImage_basic() string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img1" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
   copy_aliases = true
 }
@@ -254,7 +254,7 @@ func testAccCachedImage_aliases(aliases ...string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img2" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -266,7 +266,7 @@ func testAccCachedImage_aliasExists1(alias string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "exists1" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -278,7 +278,7 @@ func testAccCachedImage_aliasExists2(alias string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "exists1" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -286,7 +286,7 @@ resource "lxd_cached_image" "exists1" {
 
 resource "lxd_cached_image" "exists2" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
   aliases = ["%s"]
   copy_aliases = false
@@ -298,9 +298,9 @@ func testAccCachedImage_aliases2(aliases ...string) string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img3" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
-  aliases = ["alpine/3.9","%s"]
+  aliases = ["alpine/3.12","%s"]
   copy_aliases = true
 }
 	`, strings.Join(aliases, `","`))
@@ -310,9 +310,9 @@ func testAccCachedImage_aliasCollision() string {
 	return fmt.Sprintf(`
 resource "lxd_cached_image" "img4" {
   source_remote = "images"
-  source_image = "alpine/3.9"
+  source_image = "alpine/3.12"
 
-  aliases = ["alpine/3.9/amd64"]
+  aliases = ["alpine/3.12/amd64"]
   copy_aliases = true
 }
 	`)

--- a/lxd/resource_lxd_container_file_test.go
+++ b/lxd/resource_lxd_container_file_test.go
@@ -91,7 +91,7 @@ func testAccContainerFile_content(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 }
 
@@ -108,7 +108,7 @@ func testAccContainerFile_source(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 }
 

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -614,7 +614,7 @@ func testAccContainer_basic(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -624,7 +624,7 @@ func testAccContainer_config(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
   config = {
     "boot.autostart" = 1
@@ -641,7 +641,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 	`, profileName, containerName)
@@ -655,7 +655,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -669,7 +669,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -683,7 +683,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 	`, profileName, containerName)
@@ -693,7 +693,7 @@ func testAccContainer_device_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   device {
@@ -712,7 +712,7 @@ func testAccContainer_device_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   device {
@@ -731,7 +731,7 @@ func testAccContainer_addDevice_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -741,7 +741,7 @@ func testAccContainer_addDevice_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   device {
@@ -760,7 +760,7 @@ func testAccContainer_removeDevice_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   device {
@@ -779,7 +779,7 @@ func testAccContainer_removeDevice_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -789,7 +789,7 @@ func testAccContainer_fileUploadContent_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   file {
@@ -806,7 +806,7 @@ func testAccContainer_fileUploadContent_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   file {
@@ -823,7 +823,7 @@ func testAccContainer_fileUploadSource(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   file {
@@ -840,7 +840,7 @@ func testAccContainer_remoteImage(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 }
 	`, name)
@@ -850,7 +850,7 @@ func testAccContainer_defaultProfile(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
 }
 	`, name)
 }
@@ -859,7 +859,7 @@ func testAccContainer_configLimits_1(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   limits = {
@@ -873,7 +873,7 @@ func testAccContainer_configLimits_2(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   limits = {
@@ -898,7 +898,7 @@ resource "lxd_network" "network_1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   config = {
@@ -924,7 +924,7 @@ func testAccContainer_withDevice(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   device {
@@ -944,7 +944,7 @@ func testAccContainer_isStopped(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   start_container = false
@@ -956,14 +956,14 @@ func testAccContainer_target(name string, target string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s-1"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
   target = "%s"
 }
 
 resource "lxd_container" "container2" {
   name = "%s-2"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
   target = "%s"
 }

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -216,7 +216,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 `, profileName, containerName)
@@ -239,7 +239,7 @@ resource "lxd_network" "eth1" {
 # be deleted, but must be updated in-place.
 resource "lxd_container" "c1" {
   name             = "%s"
-  image            = "images:alpine/3.9"
+  image            = "images:alpine/3.12"
   wait_for_network = false
 
   device {
@@ -271,7 +271,7 @@ resource "lxd_network" "eth1" {
 # be deleted, but must be updated in-place.
 resource "lxd_container" "c1" {
   name             = "%s"
-  image            = "images:alpine/3.9"
+  image            = "images:alpine/3.12"
   wait_for_network = false
 
   device {

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -460,7 +460,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)
@@ -482,7 +482,7 @@ resource "lxd_profile" "profile1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default", "${lxd_profile.profile1.name}"]
 }
 	`, profileName, containerName)

--- a/lxd/resource_lxd_publish_image_test.go
+++ b/lxd/resource_lxd_publish_image_test.go
@@ -87,7 +87,7 @@ func testAccPublishImage_basic(name string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   start_container = false
@@ -106,7 +106,7 @@ func testAccPublishImage_aliases(name string, aliases []interface{}) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   start_container = false
@@ -125,7 +125,7 @@ func testAccPublishImage_properties(name string, properties map[string]string) s
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   start_container = false

--- a/lxd/resource_lxd_snapshot_test.go
+++ b/lxd/resource_lxd_snapshot_test.go
@@ -149,7 +149,7 @@ func testAccSnapshot_basic(cName, sName string, stateful bool) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 
@@ -165,7 +165,7 @@ func testAccSnapshot_multiple1(cName, sName string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 
@@ -181,7 +181,7 @@ func testAccSnapshot_multiple2(cName, sName1, sName2 string) string {
 	return fmt.Sprintf(`
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -101,7 +101,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 
@@ -131,7 +131,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9"
+  image = "images:alpine/3.12"
   profiles = ["default"]
 }
 

--- a/lxd/resource_lxd_volume_test.go
+++ b/lxd/resource_lxd_volume_test.go
@@ -137,7 +137,7 @@ resource "lxd_volume" "volume1" {
 
 resource "lxd_container" "container1" {
   name = "%s"
-  image = "images:alpine/3.9/amd64"
+  image = "images:alpine/3.12/amd64"
   profiles = ["default"]
 
   device {


### PR DESCRIPTION
The alpine/3.9 images has reached EOL and is not longer distributed by the LXD image servers.

---

I did thought about changing this to `alpine/edge` which should always be available but I am not sure about implications or previous experience and only changed to `alpine/3.12`.

With this the test suite is passing again. I'll rebase #215 after this has been merged.